### PR TITLE
add compatibility for monolog/monolog:^1.24

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,13 @@
         "symfony/monolog-bundle": "^3.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
+        "doctrine/doctrine-bundle": "^1.4",
+        "doctrine/orm": "^2.5.14",
+        "doctrine/persistence": "^1.3",
         "mockery/mockery": "^1.2",
         "paysera/lib-php-cs-fixer-config": "^2.3",
-        "symfony/yaml": "^3.4.34|^4.3",
-        "doctrine/doctrine-bundle": "^1.4",
-        "doctrine/orm": "^2.5.14"
+        "phpunit/phpunit": "^6.5",
+        "symfony/yaml": "^3.4.34|^4.3"
     },
     "config": {
         "bin-dir": "bin",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "php": ">=7.2,<7.5",
         "ext-json": "*",
         "graylog2/gelf-php": "^1.4.2",
+        "monolog/monolog": "^2.0 || ^1.24",
         "sentry/sentry-symfony": "^3.0",
         "symfony/framework-bundle": "^3.4.26|^4.2.7",
         "symfony/monolog-bundle": "^3.4"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=7.2,<7.5",
         "ext-json": "*",
         "graylog2/gelf-php": "^1.4.2",
-        "monolog/monolog": "^2.0 || ^1.24",
+        "monolog/monolog": "^1.24 || ^2.0",
         "sentry/sentry-symfony": "^3.0",
         "symfony/framework-bundle": "^3.4.26|^4.2.7",
         "symfony/monolog-bundle": "^3.4"

--- a/src/Service/Formatter/FormatterTrait.php
+++ b/src/Service/Formatter/FormatterTrait.php
@@ -96,7 +96,7 @@ trait FormatterTrait
      *
      * @return string
      */
-    protected function toJson($data, $ignoreErrors = false)
+    protected function toJson($data, $ignoreErrors = false): string
     {
         return Utils::jsonEncode(
             $data,

--- a/src/Service/Formatter/FormatterTrait.php
+++ b/src/Service/Formatter/FormatterTrait.php
@@ -96,7 +96,7 @@ trait FormatterTrait
      *
      * @return string
      */
-    protected function toJson($data, $ignoreErrors = false): string
+    protected function toJson($data, $ignoreErrors = false)
     {
         return Utils::jsonEncode(
             $data,

--- a/src/Service/Formatter/FormatterTrait.php
+++ b/src/Service/Formatter/FormatterTrait.php
@@ -90,12 +90,6 @@ trait FormatterTrait
         return '[Uninitialized]';
     }
 
-    /**
-     * @param $data
-     * @param bool $ignoreErrors
-     *
-     * @return string
-     */
     protected function toJson($data, $ignoreErrors = false): string
     {
         return Utils::jsonEncode(

--- a/src/Service/Formatter/FormatterTrait.php
+++ b/src/Service/Formatter/FormatterTrait.php
@@ -16,7 +16,7 @@ use Throwable;
  */
 trait FormatterTrait
 {
-    protected function normalize($data, int $depth = 0)
+    protected function normalize($data, $depth = 0)
     {
         $prenormalizedData = $this->prenormalizeData($data, $depth);
 
@@ -90,7 +90,13 @@ trait FormatterTrait
         return '[Uninitialized]';
     }
 
-    protected function toJson($data, bool $ignoreErrors = false): string
+    /**
+     * @param $data
+     * @param bool $ignoreErrors
+     *
+     * @return string
+     */
+    protected function toJson($data, $ignoreErrors = false): string
     {
         return Utils::jsonEncode(
             $data,


### PR DESCRIPTION
Bump patch.

Currently, this lib is only compatible with `monolog/monolog` version 2. These strictly typed method parameters conflict with the Monolog's `NormalizerFormatter` method parameters when using `monolog/monolog` version ^1.24 (since the strict types were added in the `monolog/monolog:2.0.0` version), therefore, this pull request is to remove them and make the lib compatible with both `monolog/monolog` versions.