### PR TITLE
Add PHP 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ phpunit.xml
 composer.lock
 bin/
 var/
+.phpunit.result.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,9 +1,0 @@
-<?php
-declare(strict_types=1);
-
-include __DIR__ . '/vendor/autoload.php';
-
-return Paysera\PhpCsFixerConfig\Config\PayseraConventionsConfig::create()
-    ->setDefaultFinder(['src', 'tests'], [])
-    ->setRiskyRules()
-;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,25 @@ matrix:
       - php: 7.3
         env: COMPOSER_ARGS=""
       - php: 7.4
-        env: COMPOSER_ARGS="" WITH_CS="true"
+        env: COMPOSER_ARGS=""
+      - php: 8.0
+        env: COMPOSER_ARGS=""
+      - php: 8.1
+        env: COMPOSER_ARGS=""
+      - php: 8.2
+        env: COMPOSER_ARGS=""
 
       - php: 7.2
         env: COMPOSER_ARGS="--prefer-lowest"
       - php: 7.3
         env: COMPOSER_ARGS="--prefer-lowest"
       - php: 7.4
+        env: COMPOSER_ARGS="--prefer-lowest"
+      - php: 8.0
+        env: COMPOSER_ARGS="--prefer-lowest"
+      - php: 8.1
+        env: COMPOSER_ARGS="--prefer-lowest"
+      - php: 8.2
         env: COMPOSER_ARGS="--prefer-lowest"
 
 cache:
@@ -35,4 +47,3 @@ before_script:
 
 script:
     - bin/phpunit
-    - if [[ "$WITH_CS" == "true" ]]; then bin/paysera-php-cs-fixer fix -v --config=.php_cs --dry-run --stop-on-violation --path-mode=intersection "${COMMIT_SCA_FILES[@]}"; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2023-02-24
+### Added
+- PHP 8 support
+
 ## [1.0.2] - 2022-08-30
 ### Fixed
 - Fixing deprecation error in symfony versions above 4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0] - 2023-02-24
+## [2.0.0] - 2023-03-09
 ### Added
 - PHP 8 support
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ monolog:
             channels: ["!event", "!doctrine"]
         sentry:
             type: service
-            id: Sentry\Monolog\Handler
+            id: paysera_logging_extra.sentry_handler
 
         graylog_fingers_crossed:
             type: fingers_crossed
@@ -89,10 +89,8 @@ monolog:
 sentry:
     dsn: '%env(SENTRY_DSN)%'
     register_error_listener: false
-    monolog:
-        error_handler:
-            enabled: true
-            level: error
+    tracing:
+        enabled: false # If using self-hosted Sentry version < v20.6.0
     options:
         environment: '%kernel.environment%'
         release: '%env(VERSION)%' # your app version, optional
@@ -100,7 +98,6 @@ sentry:
 
 paysera_logging_extra:
   application_name: app-something   # customise this to know which project message was sent from
-
 ```
 
 ## Usage
@@ -140,11 +137,6 @@ composer test
 ## Contributing
 
 Feel free to create issues and give pull requests.
-
-You can fix any code style issues using this command:
-```
-composer fix-cs
-```
 
 ### Running dependencies locally
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ monolog:
         sentry:
             type: service
             id: paysera_logging_extra.sentry_handler
-
         graylog_fingers_crossed:
             type: fingers_crossed
             action_level: error

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,4 +1,4 @@
-# Upgrade 1.x to 2.0
+# Upgrade from 1.x to 2.0
 The `sentry/sentry-symfony` package is updated to ^4.0 which requires changes in the configuration if you use the recommended configuration:
 
 - Remove `sentry.monolog` configuration option  

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,75 @@
+# Upgrade 1.x to 2.0
+The `sentry/sentry-symfony` package is updated to ^4.0 which requires changes in the configuration if you use the recommended configuration:
+
+- Remove `sentry.monolog` configuration option  
+
+Before:
+```yaml
+sentry:
+    dsn: '%env(SENTRY_DSN)%'
+    register_error_listener: false
+    monolog:
+        error_handler:
+            enabled: true
+            level: error
+    options:
+        environment: '%kernel.environment%'
+        release: '%env(VERSION)%' # your app version, optional
+        send_attempts: 1
+```
+
+After:
+```yaml
+sentry:
+    dsn: '%env(SENTRY_DSN)%'
+    register_error_listener: false
+    options:
+        environment: '%kernel.environment%'
+        release: '%env(VERSION)%' # your app version, optional
+        send_attempts: 1
+```
+
+- Update the sentry monolog handler to `paysera_logging_extra.sentry_handler`
+
+Before:
+```yaml
+monolog:
+    handlers:
+        ...
+        sentry:
+            type: service
+            id: Sentry\Monolog\Handler
+        ...
+```
+
+After:
+```yaml
+monolog:
+    handlers:
+        ...
+        sentry:
+            type: service
+            id: paysera_logging_extra.sentry_handler
+        ...
+```
+
+- Due to a bug in all versions below 6.0 of the SensioFrameworkExtraBundle bundle, you will likely receive an error during the execution of the command above related to the missing `Nyholm\Psr7\Factory\Psr17Factory` class. To workaround the issue, if you are not using the PSR-7 bridge, please change the configuration of that bundle as follows:
+
+```yaml
+sensio_framework_extra:
+   psr_message:
+      enabled: false
+```
+
+For more details about the issue see https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/710.
+
+- The version of `sentry/sentry` was upgraded to ^3.0. If you're using self-hosted Sentry version < v20.6.0 then you should disable the tracing as it uses the envelope endpoint which requires Sentry version >= v20.6.0 to work.
+
+```yaml
+sentry:
+  tracing:
+    enabled: false
+```
+
+Check the [UPGRADE-3.0.md](https://github.com/getsentry/sentry-php/blob/master/UPGRADE-3.0.md) file of `sentry/sentry` for other notable updates.   
+Check the [UPGRADE-4.0.md](https://github.com/getsentry/sentry-symfony/blob/4.6.0/UPGRADE-4.0.md) file of `sentry/sentry-symfony` for other notable updates.

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -53,7 +53,7 @@ monolog:
         ...
 ```
 
-- Due to a bug in all versions below 6.0 of the SensioFrameworkExtraBundle bundle, you will likely receive an error during the execution of the command above related to the missing `Nyholm\Psr7\Factory\Psr17Factory` class. To workaround the issue, if you are not using the PSR-7 bridge, please change the configuration of that bundle as follows:
+- Due to a bug in all versions below 6.0 of the SensioFrameworkExtraBundle bundle, you will likely receive an error during the building of symfony container related to the missing `Nyholm\Psr7\Factory\Psr17Factory` class. To workaround the issue, if you are not using the PSR-7 bridge, please change the configuration of that bundle as follows:
 
 ```yaml
 sensio_framework_extra:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.14",
-        "doctrine/doctrine-bundle": "~2.6.4",
+        "doctrine/doctrine-bundle": "~2.6.0",
         "doctrine/orm": "^2.10",
         "phpunit/phpunit": "^8.5",
         "symfony/yaml": "^4.3"

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,13 @@
         "ext-json": "*",
         "graylog2/gelf-php": "^1.4.2",
         "monolog/monolog": "^1.24 || ^2.0",
+        "sentry/sdk": "^3.1",
+        "sentry/sentry": "^3.1",
         "sentry/sentry-symfony": "^4.0",
+        "symfony/config": "^3.4|^4.0",
+        "symfony/dependency-injection": "^3.4|^4.0",
         "symfony/framework-bundle": "^3.4.26|^4.2.7",
+        "symfony/http-kernel": "^3.4|^4.0",
         "symfony/monolog-bundle": "^3.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,22 +15,20 @@
         }
     },
     "require": {
-        "php": ">=7.2,<7.5",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "graylog2/gelf-php": "^1.4.2",
         "monolog/monolog": "^1.24 || ^2.0",
-        "sentry/sentry-symfony": "^3.0",
+        "sentry/sentry-symfony": "^4.0",
         "symfony/framework-bundle": "^3.4.26|^4.2.7",
         "symfony/monolog-bundle": "^3.4"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "^1.4",
-        "doctrine/orm": "^2.5.14",
-        "doctrine/persistence": "^1.3",
-        "mockery/mockery": "^1.2",
-        "paysera/lib-php-cs-fixer-config": "^2.3",
-        "phpunit/phpunit": "^6.5",
-        "symfony/yaml": "^3.4.34|^4.3"
+        "doctrine/annotations": "^1.14",
+        "doctrine/doctrine-bundle": "~2.6.4",
+        "doctrine/orm": "^2.10",
+        "phpunit/phpunit": "^8.5",
+        "symfony/yaml": "^4.3"
     },
     "config": {
         "bin-dir": "bin",
@@ -38,8 +36,6 @@
     },
     "scripts": {
         "phpunit": "phpunit",
-        "fix-cs": "paysera-php-cs-fixer fix",
-        "test-cs": "paysera-php-cs-fixer fix --dry-run -v",
-        "test": ["@phpunit", "@test-cs"]
+        "test": ["@phpunit"]
     }
 }

--- a/example/basic.yml
+++ b/example/basic.yml
@@ -18,7 +18,6 @@ monolog:
         sentry:
             type: service
             id: paysera_logging_extra.sentry_handler
-
         graylog_fingers_crossed:
             type: fingers_crossed
             action_level: error

--- a/example/basic.yml
+++ b/example/basic.yml
@@ -17,7 +17,7 @@ monolog:
             channels: ["!event", "!doctrine"]
         sentry:
             type: service
-            id: Sentry\Monolog\Handler
+            id: paysera_logging_extra.sentry_handler
 
         graylog_fingers_crossed:
             type: fingers_crossed
@@ -42,10 +42,6 @@ monolog:
 sentry:
     dsn: '%env(SENTRY_DSN)%'
     register_error_listener: false
-    monolog:
-        error_handler:
-            enabled: true
-            level: error
     options:
         environment: '%kernel.environment%'
         release: 'v123'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "vendor/autoload.php" >
 
     <testsuites>

--- a/src/Listener/IterationEndListener.php
+++ b/src/Listener/IterationEndListener.php
@@ -6,7 +6,6 @@ namespace Paysera\LoggingExtraBundle\Listener;
 
 use Paysera\LoggingExtraBundle\Service\CorrelationIdProvider;
 use Sentry\ClientInterface;
-use Sentry\FlushableClientInterface;
 
 /**
  * Intended for cases where the same process is reused for separate job or request processing, like in PHPPM.
@@ -24,7 +23,7 @@ class IterationEndListener
         ClientInterface $sentryClient = null
     ) {
         $this->correlationIdProvider = $correlationIdProvider;
-        $this->sentryClient = $sentryClient instanceof FlushableClientInterface ? $sentryClient : null;
+        $this->sentryClient = $sentryClient instanceof ClientInterface ? $sentryClient : null;
     }
 
     public function afterIteration()

--- a/src/Monolog/SentryHandler.php
+++ b/src/Monolog/SentryHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Monolog;
+
+use Monolog\Handler\HandlerWrapper;
+use Monolog\Handler\ProcessableHandlerTrait;
+use Sentry\State\Scope;
+use function Sentry\withScope;
+
+final class SentryHandler extends HandlerWrapper
+{
+    use ProcessableHandlerTrait;
+
+    public function handle(array $record): bool
+    {
+        if (!$this->isHandling($record)) {
+            return false;
+        }
+
+        $result = false;
+        $record = $this->processRecord($record);
+
+        $record['formatted'] = $this->getFormatter()->format($record);
+
+        withScope(function (Scope $scope) use ($record, &$result): void {
+            if (isset($record['context']['extra']) && \is_array($record['context']['extra'])) {
+                foreach ($record['context']['extra'] as $key => $value) {
+                    $scope->setExtra((string) $key, $value);
+                }
+            }
+
+            if (isset($record['context']['tags']) && \is_array($record['context']['tags'])) {
+                foreach ($record['context']['tags'] as $key => $value) {
+                    $scope->setTag($key, $value);
+                }
+            }
+
+            $result = $this->handler->handle($record);
+        });
+
+        return $result;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,14 +14,6 @@
             <argument>%paysera_logging_extra.application_name%</argument>
         </service>
 
-        <service id="paysera_logging_extra.sentry_handler"
-                 class="Paysera\LoggingExtraBundle\Monolog\SentryHandler">
-            <argument type="service">
-                <service class="Sentry\Monolog\Handler">
-                    <argument type="service" id="Sentry\State\HubInterface"/>
-                    <argument type="constant">Monolog\Logger::ERROR</argument>
-                </service>
-            </argument>
-        </service>
+        <service id="paysera_logging_extra.sentry_handler" alias="paysera_logging_extra.handler.sentry"/>
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,5 +13,15 @@
                  class="Paysera\LoggingExtraBundle\Service\CorrelationIdProvider">
             <argument>%paysera_logging_extra.application_name%</argument>
         </service>
+
+        <service id="paysera_logging_extra.sentry_handler"
+                 class="Paysera\LoggingExtraBundle\Monolog\SentryHandler">
+            <argument type="service">
+                <service class="Sentry\Monolog\Handler">
+                    <argument type="service" id="Sentry\State\HubInterface"/>
+                    <argument type="constant">Monolog\Logger::ERROR</argument>
+                </service>
+            </argument>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/handlers.xml
+++ b/src/Resources/config/services/handlers.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="paysera_logging_extra.handler.sentry"
+                 class="Paysera\LoggingExtraBundle\Service\Handler\SentryExtraInformationHandler">
+            <argument type="service">
+                <service class="Sentry\Monolog\Handler">
+                    <argument type="service" id="Sentry\State\HubInterface"/>
+                    <argument type="constant">Monolog\Logger::ERROR</argument>
+                </service>
+            </argument>
+        </service>
+    </services>
+</container>

--- a/src/Service/Handler/SentryExtraInformationHandler.php
+++ b/src/Service/Handler/SentryExtraInformationHandler.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Paysera\LoggingExtraBundle\Monolog;
+namespace Paysera\LoggingExtraBundle\Service\Handler;
 
 use Monolog\Handler\HandlerWrapper;
 use Monolog\Handler\ProcessableHandlerTrait;
 use Sentry\State\Scope;
 use function Sentry\withScope;
 
-final class SentryHandler extends HandlerWrapper
+final class SentryExtraInformationHandler extends HandlerWrapper
 {
     use ProcessableHandlerTrait;
 

--- a/src/Service/Processor/GroupExceptionsProcessor.php
+++ b/src/Service/Processor/GroupExceptionsProcessor.php
@@ -6,6 +6,7 @@ namespace Paysera\LoggingExtraBundle\Service\Processor;
 
 use Monolog\Processor\ProcessorInterface;
 use Sentry\SentryBundle\SentryBundle;
+use Sentry\SentrySdk;
 use Sentry\State\Scope;
 
 /**
@@ -30,7 +31,7 @@ class GroupExceptionsProcessor implements ProcessorInterface
         $exceptionClass = get_class($exception);
 
         if (isset($this->exceptionsClassesToGroup[$exceptionClass])) {
-            SentryBundle::getCurrentHub()
+            SentrySdk::getCurrentHub()
                 ->configureScope(function (Scope $scope) use ($exceptionClass) {
                     $scope->setFingerprint([$exceptionClass]);
                 })

--- a/tests/Functional/Fixtures/Handler/TestSentryTransport.php
+++ b/tests/Functional/Fixtures/Handler/TestSentryTransport.php
@@ -10,7 +10,7 @@ use Sentry\Event;
 use Sentry\Transport\ClosableTransportInterface;
 use Sentry\Transport\TransportInterface;
 
-class TestSentryTransport implements TransportInterface, ClosableTransportInterface
+class TestSentryTransport implements TransportInterface
 {
     private $pendingEvents;
     private $events;
@@ -23,10 +23,10 @@ class TestSentryTransport implements TransportInterface, ClosableTransportInterf
         $this->id = 0;
     }
 
-    public function send(Event $event): ?string
+    public function send(Event $event): PromiseInterface
     {
         $this->pendingEvents[] = $event;
-        return (string)$this->id++;
+        return new FulfilledPromise($this->id++);
     }
 
     public function close(?int $timeout = null): PromiseInterface

--- a/tests/Functional/Fixtures/Service/TestTransportFactory.php
+++ b/tests/Functional/Fixtures/Service/TestTransportFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Tests\Functional\Fixtures\Service;
+
+use Sentry\Options;
+use Sentry\Transport\TransportFactoryInterface;
+use Sentry\Transport\TransportInterface;
+
+class TestTransportFactory implements TransportFactoryInterface
+{
+    /**
+     * @var TransportInterface
+     */
+    private $transport;
+
+    public function __construct(TransportInterface $transport)
+    {
+        $this->transport = $transport;
+    }
+
+    public function create(Options $options): TransportInterface
+    {
+        return $this->transport;
+    }
+}

--- a/tests/Functional/Fixtures/config/cases/basic.yml
+++ b/tests/Functional/Fixtures/config/cases/basic.yml
@@ -15,7 +15,6 @@ monolog:
         sentry:
             type: service
             id: paysera_logging_extra.sentry_handler
-            
         graylog_fingers_crossed:
             type: fingers_crossed
             action_level: error

--- a/tests/Functional/Fixtures/config/cases/basic.yml
+++ b/tests/Functional/Fixtures/config/cases/basic.yml
@@ -14,8 +14,8 @@ monolog:
             channels: ["!event", "!doctrine"]
         sentry:
             type: service
-            id: Sentry\Monolog\Handler
-
+            id: paysera_logging_extra.sentry_handler
+            
         graylog_fingers_crossed:
             type: fingers_crossed
             action_level: error
@@ -39,10 +39,6 @@ monolog:
 sentry:
     dsn: 'http://user:password@non-existant:213/1'
     register_error_listener: false
-    monolog:
-        error_handler:
-            enabled: true
-            level: error
     options:
         environment: '%kernel.environment%'
         release: 'v123'

--- a/tests/Functional/Fixtures/config/common.yml
+++ b/tests/Functional/Fixtures/config/common.yml
@@ -30,13 +30,10 @@ services:
     public_logger:
         alias: logger
         public: true
-    sentry_client_builder:
-        decorates: Sentry\ClientBuilderInterface
-        parent: Sentry\ClientBuilderInterface
-        calls:
-            - method: setTransport
-              arguments:
-                  - '@sentry_transport'
+    Sentry\Transport\TransportFactoryInterface:
+        class: \Paysera\LoggingExtraBundle\Tests\Functional\Fixtures\Service\TestTransportFactory
+        arguments:
+            $transport: '@sentry_transport'
     sentry_transport:
         class: Paysera\LoggingExtraBundle\Tests\Functional\Fixtures\Handler\TestSentryTransport
         public: true

--- a/tests/Functional/FunctionalCorrelationIdListenerTest.php
+++ b/tests/Functional/FunctionalCorrelationIdListenerTest.php
@@ -14,7 +14,7 @@ class FunctionalCorrelationIdListenerTest extends FunctionalTestCase
      */
     private $correlationIdProvider;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Functional/FunctionalFormattersTest.php
+++ b/tests/Functional/FunctionalFormattersTest.php
@@ -37,7 +37,7 @@ class FunctionalFormattersTest extends FunctionalTestCase
      */
     private $dbalLogger;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Functional/FunctionalHandlersTest.php
+++ b/tests/Functional/FunctionalHandlersTest.php
@@ -40,7 +40,7 @@ class FunctionalHandlersTest extends FunctionalTestCase
      */
     private $logger;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -57,7 +57,7 @@ class FunctionalHandlersTest extends FunctionalTestCase
         $this->logger->error('Hello world', ['param1' => 'value1']);
 
         $event = $this->getSingleSentryEvent();
-        $this->assertArraySubset(['param1' => 'value1'], $event->getExtraContext());
+        $this->assertSame('value1', $event->getExtra()['param1'] ?? null);
     }
 
     public function testCorrelationId()
@@ -66,7 +66,7 @@ class FunctionalHandlersTest extends FunctionalTestCase
         $this->logger->info('info');
         $this->logger->error('error');
 
-        $correlationId = $this->getSingleSentryEvent()->getTagsContext()['correlation_id'];
+        $correlationId = $this->getSingleSentryEvent()->getTags()['correlation_id'];
         $this->assertStringStartsWith('test-application-name', $correlationId);
 
         $correlationIds = array_map(function (Message $message) {
@@ -99,13 +99,10 @@ class FunctionalHandlersTest extends FunctionalTestCase
             'Introspection works only for errors'
         );
 
-        $this->assertArraySubset(
-            [
-                'function' => 'testIntrospection',
-                'class' => __CLASS__,
-            ],
-            $messages[1]->getAllAdditionals()
-        );
+        $allAdditionals = $messages[1]->getAllAdditionals();
+
+        $this->assertSame('testIntrospection', $allAdditionals['function'] ?? null);
+        $this->assertSame(__CLASS__, $allAdditionals['class'] ?? null);
     }
 
     public function testExceptionGrouping()

--- a/tests/Functional/FunctionalMonologConfigurationTest.php
+++ b/tests/Functional/FunctionalMonologConfigurationTest.php
@@ -39,7 +39,7 @@ class FunctionalMonologConfigurationTest extends FunctionalTestCase
      */
     private $logger;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -135,7 +135,12 @@ class FunctionalMonologConfigurationTest extends FunctionalTestCase
             /** @var Message $message */
             $message = $publishedMessages[$i];
             $this->assertSame($expectation['message'], $message->getShortMessage());
-            $this->assertArraySubset($expectation['additionals'] ?? [], $message->getAllAdditionals());
+
+            $additionalsExpectation = $expectation['additionals'] ?? [];
+            foreach ($additionalsExpectation as $key => $value) {
+                $this->assertArrayHasKey($key, $message->getAllAdditionals());
+                $this->assertSame($value, $message->getAllAdditionals()[$key]);
+            }
 
             $this->assertSame('test-application-name', $message->getHost());
             $this->assertSame('app', $message->getFacility());
@@ -149,7 +154,12 @@ class FunctionalMonologConfigurationTest extends FunctionalTestCase
             /** @var Event $event */
             $event = $publishedEvents[$i];
             $this->assertSame($expectation['message'], $event->getMessage());
-            $this->assertArraySubset($expectation['additionals'], $event->getExtraContext()->toArray());
+
+            $additionalsExpectation = $expectation['additionals'] ?? [];
+            foreach ($additionalsExpectation as $key => $value) {
+                $this->assertArrayHasKey($key, $event->getExtra());
+                $this->assertSame($value, $event->getExtra()[$key]);
+            }
 
             $this->assertSame('monolog.app', $event->getLogger());
             $this->assertSame('v123', $event->getRelease());

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -34,7 +34,7 @@ abstract class FunctionalTestCase extends TestCase
         return $this->kernel->getContainer();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $container = $this->kernel->getContainer();
         $this->kernel->shutdown();


### PR DESCRIPTION
- Added support for PHP 8.
- Upgraded `sentry/sentry-symfony` to ^4.0.
- Removed `paysera/lib-php-cs-fixer-config` as it lacks support for PHP 8.
- Breaking changes in the configuration are described in the `UPGRADE.md` file.

Tested with Sentry 9.1.2, Sentry 20.7.1, Sentry cloud.