### PR TITLE
Added config options to provide manually log levels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.1 - 2024-07-12
+### Added
+- Added config option `paysera_logging_extra.sentry.minimum_log_level` to set from which level logs will be sent to Sentry
+- Added config option `paysera_logging_extra.monolog.minimum_introspection_level` to set from which level logs will be introspected
+
 ## 2.2.0
 ### Added
 - Added Symfony ^6 support.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Paysera\LoggingExtraBundle\DependencyInjection;
 
+use Monolog\Logger;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -20,8 +21,36 @@ class Configuration implements ConfigurationInterface
         }
 
         $children = $rootNode->children();
-        $children->scalarNode('application_name')->isRequired();
-        $children->arrayNode('grouped_exceptions')->prototype('scalar');
+        $children
+            ->scalarNode('application_name')
+            ->isRequired()
+        ;
+        $children
+            ->arrayNode('grouped_exceptions')
+            ->prototype('scalar')
+        ;
+        $children
+            ->arrayNode('monolog')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('minimum_introspection_level')
+                        ->isRequired()
+                        ->defaultValue(Logger::ERROR)
+                    ->end()
+                ->end()
+            ->end()
+        ;
+        $children
+            ->arrayNode('sentry')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('minimum_log_level')
+                        ->isRequired()
+                        ->defaultValue(Logger::ERROR)
+                    ->end()
+                ->end()
+            ->end()
+        ;
 
         return $treeBuilder;
     }

--- a/src/DependencyInjection/PayseraLoggingExtraExtension.php
+++ b/src/DependencyInjection/PayseraLoggingExtraExtension.php
@@ -21,5 +21,7 @@ class PayseraLoggingExtraExtension extends Extension
 
         $container->setParameter('paysera_logging_extra.application_name', $config['application_name']);
         $container->setParameter('paysera_logging_extra.grouped_exceptions', $config['grouped_exceptions']);
+        $container->setParameter('paysera_logging_extra.monolog.minimum_introspection_level', $config['monolog']['minimum_introspection_level']);
+        $container->setParameter('paysera_logging_extra.sentry.minimum_log_level', $config['sentry']['minimum_log_level']);
     }
 }

--- a/src/Resources/config/services/handlers.xml
+++ b/src/Resources/config/services/handlers.xml
@@ -10,7 +10,7 @@
             <argument type="service">
                 <service class="Sentry\Monolog\Handler">
                     <argument type="service" id="Sentry\State\HubInterface"/>
-                    <argument type="constant">Monolog\Logger::ERROR</argument>
+                    <argument type="string">%paysera_logging_extra.sentry.minimum_log_level%</argument>
                 </service>
             </argument>
         </service>

--- a/src/Resources/config/services/processors.xml
+++ b/src/Resources/config/services/processors.xml
@@ -16,7 +16,7 @@
                  class="Monolog\Processor\IntrospectionProcessor">
             <tag name="monolog.processor"/>
 
-            <argument>ERROR</argument>
+            <argument type="string">%paysera_logging_extra.monolog.minimum_introspection_level%</argument>
         </service>
 
         <service id="paysera_logging_extra.processor.remove_root_prefix"

--- a/tests/Functional/Fixtures/config/cases/basic.yml
+++ b/tests/Functional/Fixtures/config/cases/basic.yml
@@ -47,3 +47,5 @@ paysera_logging_extra:
     application_name: test-application-name
     grouped_exceptions:
         - Doctrine\DBAL\ConnectionException
+    sentry:
+        minimum_log_level: !php/const Monolog\Logger::WARNING

--- a/tests/Functional/FunctionalMonologConfigurationTest.php
+++ b/tests/Functional/FunctionalMonologConfigurationTest.php
@@ -114,10 +114,20 @@ class FunctionalMonologConfigurationTest extends FunctionalTestCase
         $this->assertEmpty($this->sentryTransport->getEvents());
         $this->sentryClient->flush();
         $this->assertSameSentryEvents([
-            ['message' => 'Hello world', 'additionals' => [
-                'monolog.channel' => 'app',
-                'monolog.level' => 'ERROR',
-            ]],
+            [
+                'message' => 'Hello world',
+                'additionals' => [
+                    'monolog.channel' => 'app',
+                    'monolog.level' => 'WARNING',
+                ],
+            ],
+            [
+                'message' => 'Hello world',
+                'additionals' => [
+                    'monolog.channel' => 'app',
+                    'monolog.level' => 'ERROR',
+                ],
+            ],
         ], $this->sentryTransport->getEvents());
     }
 


### PR DESCRIPTION
Level from which the log is sent to Sentry is currently hardcoded inside the service definitions. 

I added options to provide the levels manually from the config parameter.

The changes are not breaking the backward compatibility as they have the same values as before and are provided by default, so if you don't want to change it, there is no need to update config.