### PR TITLE
Increase minimum required PHP version to 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ env:
 
 matrix:
     include:
-      - php: 7.2
-        env: COMPOSER_ARGS=""
-      - php: 7.3
-        env: COMPOSER_ARGS=""
       - php: 7.4
         env: COMPOSER_ARGS=""
       - php: 8.0
@@ -21,10 +17,6 @@ matrix:
       - php: 8.2
         env: COMPOSER_ARGS=""
 
-      - php: 7.2
-        env: COMPOSER_ARGS="--prefer-lowest"
-      - php: 7.3
-        env: COMPOSER_ARGS="--prefer-lowest"
       - php: 7.4
         env: COMPOSER_ARGS="--prefer-lowest"
       - php: 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.3.0
+### Changed
+- Increased minimum required `PHP` version to `7.4`
+- Dropped incompatible dependencies versions support
+
+### Fixed
+- Fixed tests on lowest dependencies versions
+
 ## 2.2.0
 ### Added
 - Added Symfony ^6 support.

--- a/composer.json
+++ b/composer.json
@@ -15,19 +15,19 @@
         }
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "graylog2/gelf-php": "^1.4.2",
-        "monolog/monolog": "^1.24 || ^2.0",
+        "monolog/monolog": "^2.1.0",
         "sentry/sdk": "^3.1",
         "sentry/sentry": "^3.1",
         "sentry/sentry-symfony": "^4.0",
-        "symfony/config": "^3.4|^4.0|^5.0|^6.0",
-        "symfony/dependency-injection": "^3.4|^4.0|^5.0|^6.0",
+        "symfony/config": "^4.0|^5.0|^6.0",
+        "symfony/dependency-injection": "^4.0|^5.0|^6.0",
         "symfony/expression-language": "^3.0 || ^4.0 || ^5.0 || ^6.0",
         "symfony/framework-bundle": "^3.4.26|^4.2.7|^5.0|^6.0",
-        "symfony/http-kernel": "^3.4|^4.0|^5.0|^6.0",
-        "symfony/monolog-bundle": "^3.4|^5.0"
+        "symfony/http-kernel": "^4.0|^5.0|^6.0",
+        "symfony/monolog-bundle": "^3.4"
     },
     "require-dev": {
         "doctrine/annotations": "^1.14",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "doctrine/annotations": "^1.14",
         "doctrine/doctrine-bundle": "~2.6.0",
         "doctrine/orm": "^2.10",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^9.5",
         "symfony/yaml": "^4.3|^5.0|^6.0"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": ">=7.4",
         "ext-json": "*",
         "graylog2/gelf-php": "^1.4.2",
         "monolog/monolog": "^2.1.0",
@@ -26,7 +26,7 @@
         "symfony/dependency-injection": "^4.0|^5.0|^6.0",
         "symfony/expression-language": "^3.0 || ^4.0 || ^5.0 || ^6.0",
         "symfony/framework-bundle": "^3.4.26|^4.2.7|^5.0|^6.0",
-        "symfony/http-kernel": "^4.0|^5.0|^6.0",
+        "symfony/http-kernel": "^4.4.11|^5.0|^6.0",
         "symfony/monolog-bundle": "^3.4"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,9 +18,9 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Listener/CorrelationIdListener.php
+++ b/src/Listener/CorrelationIdListener.php
@@ -14,7 +14,7 @@ if (class_exists(LegacyResponseEvent::class)) {
     {
         const HEADER_NAME = 'Paysera-Correlation-Id';
 
-        private $correlationIdProvider;
+        private CorrelationIdProvider $correlationIdProvider;
 
         public function __construct(CorrelationIdProvider $correlationIdProvider)
         {
@@ -38,7 +38,7 @@ if (class_exists(LegacyResponseEvent::class)) {
     {
         public const HEADER_NAME = 'Paysera-Correlation-Id';
 
-        private $correlationIdProvider;
+        private CorrelationIdProvider $correlationIdProvider;
 
         public function __construct(CorrelationIdProvider $correlationIdProvider)
         {

--- a/src/Listener/CorrelationIdListener.php
+++ b/src/Listener/CorrelationIdListener.php
@@ -5,56 +5,29 @@ declare(strict_types=1);
 namespace Paysera\LoggingExtraBundle\Listener;
 
 use Paysera\LoggingExtraBundle\Service\CorrelationIdProvider;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent as LegacyResponseEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-if (class_exists(LegacyResponseEvent::class)) {
-    class CorrelationIdListener
+class CorrelationIdListener
+{
+    public const HEADER_NAME = 'Paysera-Correlation-Id';
+
+    private CorrelationIdProvider $correlationIdProvider;
+
+    public function __construct(CorrelationIdProvider $correlationIdProvider)
     {
-        const HEADER_NAME = 'Paysera-Correlation-Id';
-
-        private CorrelationIdProvider $correlationIdProvider;
-
-        public function __construct(CorrelationIdProvider $correlationIdProvider)
-        {
-            $this->correlationIdProvider = $correlationIdProvider;
-        }
-
-        public function onKernelResponse(LegacyResponseEvent $event)
-        {
-            if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
-                return;
-            }
-
-            $event->getResponse()->headers->set(
-                self::HEADER_NAME,
-                $this->correlationIdProvider->getCorrelationId()
-            );
-        }
+        $this->correlationIdProvider = $correlationIdProvider;
     }
-} else {
-    class CorrelationIdListener
+
+    public function onKernelResponse(ResponseEvent $event): void
     {
-        public const HEADER_NAME = 'Paysera-Correlation-Id';
-
-        private CorrelationIdProvider $correlationIdProvider;
-
-        public function __construct(CorrelationIdProvider $correlationIdProvider)
-        {
-            $this->correlationIdProvider = $correlationIdProvider;
+        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+            return;
         }
 
-        public function onKernelResponse(ResponseEvent $event): void
-        {
-            if (HttpKernelInterface::MAIN_REQUEST !== $event->getRequestType()) {
-                return;
-            }
-
-            $event->getResponse()->headers->set(
-                self::HEADER_NAME,
-                $this->correlationIdProvider->getCorrelationId()
-            );
-        }
+        $event->getResponse()->headers->set(
+            self::HEADER_NAME,
+            $this->correlationIdProvider->getCorrelationId()
+        );
     }
 }

--- a/src/Listener/IterationEndListener.php
+++ b/src/Listener/IterationEndListener.php
@@ -15,15 +15,15 @@ use Sentry\ClientInterface;
  */
 class IterationEndListener
 {
-    private $correlationIdProvider;
-    private $sentryClient;
+    private CorrelationIdProvider $correlationIdProvider;
+    private ?ClientInterface $sentryClient;
 
     public function __construct(
         CorrelationIdProvider $correlationIdProvider,
         ClientInterface $sentryClient = null
     ) {
         $this->correlationIdProvider = $correlationIdProvider;
-        $this->sentryClient = $sentryClient instanceof ClientInterface ? $sentryClient : null;
+        $this->sentryClient = $sentryClient;
     }
 
     public function afterIteration()

--- a/src/Service/CorrelationIdProvider.php
+++ b/src/Service/CorrelationIdProvider.php
@@ -6,8 +6,8 @@ namespace Paysera\LoggingExtraBundle\Service;
 
 class CorrelationIdProvider
 {
-    private $correlationId;
-    private $increment;
+    private string $correlationId;
+    private int $increment;
 
     public function __construct(string $systemName)
     {

--- a/src/Service/Processor/CorrelationIdProcessor.php
+++ b/src/Service/Processor/CorrelationIdProcessor.php
@@ -9,7 +9,7 @@ use Paysera\LoggingExtraBundle\Service\CorrelationIdProvider;
 
 class CorrelationIdProcessor implements ProcessorInterface
 {
-    private $correlationIdProvider;
+    private CorrelationIdProvider $correlationIdProvider;
 
     public function __construct(CorrelationIdProvider $correlationIdProvider)
     {

--- a/src/Service/Processor/GroupExceptionsProcessor.php
+++ b/src/Service/Processor/GroupExceptionsProcessor.php
@@ -13,7 +13,7 @@ use Sentry\State\Scope;
  */
 class GroupExceptionsProcessor implements ProcessorInterface
 {
-    private $exceptionsClassesToGroup;
+    private array $exceptionsClassesToGroup;
 
     public function __construct(array $exceptionsClassesToGroup)
     {

--- a/src/Service/Processor/RemoveRootPrefixProcessor.php
+++ b/src/Service/Processor/RemoveRootPrefixProcessor.php
@@ -9,14 +9,15 @@ use InvalidArgumentException;
 
 class RemoveRootPrefixProcessor implements ProcessorInterface
 {
-    private $rootPrefix;
+    private string $rootPrefix;
 
     public function __construct(string $rootPrefix)
     {
-        $this->rootPrefix = realpath($rootPrefix);
-        if ($this->rootPrefix === false) {
+        $realPath = realpath($rootPrefix);
+        if ($realPath === false) {
             throw new InvalidArgumentException('Invalid root prefix specified');
         }
+        $this->rootPrefix = $realPath;
     }
 
     public function __invoke(array $record)

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -65,6 +65,7 @@ abstract class FunctionalTestCase extends TestCase
             'REQUEST_METHOD' => $method,
             'HTTP_PHP_AUTH_USER' => $username,
             'HTTP_PHP_AUTH_PW' => $username !== null ? 'pass' : null,
+            'REMOTE_ADDR' => '127.0.0.1',
         ]), $content);
         $request->headers->add($headers);
         return $request;


### PR DESCRIPTION
Dependencies versions changes:
- `"monolog/monolog": "^1.24"` does not work anymore because `SentryExtraInformationHandler` uses `ProcessableHandlerTrait`, which is not present in this version
- `"monolog/monolog"` increased from `2.0.0` to `2.1.0`, because `2.0.0` does not have  `Utils::jsonEncode()` which is used in `\Paysera\LoggingExtraBundle\Service\Formatter\FormatterTrait::toJson`
- `"symfony/http-kernel": "^3.4"` is not supported anymore because it conflicts with other dependencies (`symfony/monolog-bundle`, `symfony/monolog-bridge`)