### PR TITLE
PLT-1764: Sanitize sensitive fields in FormatterTrait object normaliz…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.3.0
+### Added
+- Sanitization of sensitive fields (password, secret, apiKey, etc.) in `FormatterTrait` object normalization
+
 ## 3.2.1
 ### Fixed
 - Changed versions for graylog2/gelf-php

--- a/src/Service/Formatter/FormatterTrait.php
+++ b/src/Service/Formatter/FormatterTrait.php
@@ -13,6 +13,16 @@ use Throwable;
 
 trait FormatterTrait
 {
+    /** @var string[] */
+    private static $sensitiveKeys = [
+        'password',
+        'secret',
+        'apikey',
+        'apisecret',
+        'apisecretkey',
+        'secretkey',
+        'credentials',
+    ];
     /**
      * Normalizes given data with pre-processing for Doctrine entities and collections.
      *
@@ -93,6 +103,12 @@ trait FormatterTrait
             $parts = explode("\0", $key);
             $fixedKey = end($parts);
             if (substr($fixedKey, 0, 2) === '__') {
+                continue;
+            }
+
+            $normalizedKey = preg_replace('/[^a-z]/', '', strtolower($fixedKey));
+            if (in_array($normalizedKey, self::$sensitiveKeys, true)) {
+                $result[$fixedKey] = '***';
                 continue;
             }
 

--- a/tests/Unit/FormatterTraitTest.php
+++ b/tests/Unit/FormatterTraitTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Paysera\LoggingExtraBundle\Service\Formatter\FormatterTrait;
+
+class FormatterTraitTest extends TestCase
+{
+    /**
+     * @dataProvider sensitiveKeysProvider
+     */
+    public function testSensitiveKeysAreRedacted(string $propertyName)
+    {
+        $object = new \stdClass();
+        $object->$propertyName = 'sensitive_value';
+        $object->name = 'visible';
+
+        $result = $this->normalizeObject($object);
+
+        $this->assertSame('***', $result[$propertyName]);
+        $this->assertSame('visible', $result['name']);
+    }
+
+    public function sensitiveKeysProvider(): array
+    {
+        return [
+            'password' => ['password'],
+            'secret' => ['secret'],
+            'apiKey' => ['apiKey'],
+            'apiSecret' => ['apiSecret'],
+            'secretKey' => ['secretKey'],
+            'credentials' => ['credentials'],
+        ];
+    }
+
+    /**
+     * @dataProvider caseInsensitiveProvider
+     */
+    public function testSensitiveKeysAreCaseInsensitive(string $propertyName)
+    {
+        $object = new \stdClass();
+        $object->$propertyName = 'sensitive_value';
+
+        $result = $this->normalizeObject($object);
+
+        $this->assertSame('***', $result[$propertyName]);
+    }
+
+    public function caseInsensitiveProvider(): array
+    {
+        return [
+            'Password' => ['Password'],
+            'PASSWORD' => ['PASSWORD'],
+            'pAsSwOrD' => ['pAsSwOrD'],
+            'SECRET' => ['SECRET'],
+            'ApiKey' => ['ApiKey'],
+            'APIKEY' => ['APIKEY'],
+            'Credentials' => ['Credentials'],
+        ];
+    }
+
+    /**
+     * @dataProvider separatorVariantsProvider
+     */
+    public function testSensitiveKeysWithSeparators(string $propertyName)
+    {
+        $object = new \stdClass();
+        $object->$propertyName = 'sensitive_value';
+
+        $result = $this->normalizeObject($object);
+
+        $this->assertSame('***', $result[$propertyName]);
+    }
+
+    public function separatorVariantsProvider(): array
+    {
+        return [
+            'api_key' => ['api_key'],
+            'api-key' => ['api-key'],
+            'api.key' => ['api.key'],
+            'api_secret' => ['api_secret'],
+            'api-secret' => ['api-secret'],
+            'secret_key' => ['secret_key'],
+            'secret-key' => ['secret-key'],
+            'api_secret_key' => ['api_secret_key'],
+            'api-secret-key' => ['api-secret-key'],
+            'API_KEY' => ['API_KEY'],
+            'API_SECRET' => ['API_SECRET'],
+            'SECRET_KEY' => ['SECRET_KEY'],
+        ];
+    }
+
+    public function testNonSensitivePropertiesPassThrough()
+    {
+        $object = new \stdClass();
+        $object->name = 'John';
+        $object->email = 'john@example.com';
+        $object->age = 30;
+        $object->active = true;
+
+        $result = $this->normalizeObject($object);
+
+        $this->assertSame('John', $result['name']);
+        $this->assertSame('john@example.com', $result['email']);
+        $this->assertSame(30, $result['age']);
+        $this->assertTrue($result['active']);
+    }
+
+    public function testDoubleUnderscorePrefixedPropertiesAreExcluded()
+    {
+        $object = new \stdClass();
+        $object->__internal = 'hidden';
+        $object->name = 'visible';
+
+        $result = $this->normalizeObject($object);
+
+        $this->assertArrayNotHasKey('__internal', $result);
+        $this->assertSame('visible', $result['name']);
+    }
+
+    public function testMixedSensitiveAndNonSensitiveProperties()
+    {
+        $object = new \stdClass();
+        $object->username = 'admin';
+        $object->password = 'super_secret';
+        $object->email = 'admin@example.com';
+        $object->apiKey = 'key-123';
+        $object->role = 'admin';
+        $object->credentials = ['token' => 'abc'];
+
+        $result = $this->normalizeObject($object);
+
+        $this->assertSame('admin', $result['username']);
+        $this->assertSame('***', $result['password']);
+        $this->assertSame('admin@example.com', $result['email']);
+        $this->assertSame('***', $result['apiKey']);
+        $this->assertSame('admin', $result['role']);
+        $this->assertSame('***', $result['credentials']);
+    }
+
+    private function normalizeObject(object $data): array
+    {
+        $formatter = new class {
+            use FormatterTrait;
+
+            public function callNormalizeObject(object $data): array
+            {
+                return $this->normalizeObject($data);
+            }
+        };
+
+        return $formatter->callNormalizeObject($data);
+    }
+}


### PR DESCRIPTION
- FormatterTrait::normalizeObject() now redacts known sensitive property names (password, secret, apiKey, apiSecret, apiSecretKey, secretKey, credentials) replacing their values with ***
- Matching is case-insensitive and ignores non-letter separators, so variants like api_key, API-SECRET, secret.key are all caught
- Added unit tests covering default sensitive keys, case insensitivity, separator variants, non-sensitive passthrough, and mixed properties