### PR TITLE
LW-3297 Capture parent correlation ID from incoming requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.3.0
+### Added
+- Added `ParentCorrelationIdProvider` for extracting parent correlation ID from incoming request headers
+- Added `ParentCorrelationIdListener` for capturing parent correlation ID on kernel request
+- Added `ParentCorrelationIdProcessor` for appending parent correlation ID to log records
+- Registered parent correlation ID services in DI configuration
+
 ## 3.2.1
 ### Fixed
 - Changed versions for graylog2/gelf-php

--- a/src/Listener/IterationEndListener.php
+++ b/src/Listener/IterationEndListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Paysera\LoggingExtraBundle\Listener;
 
 use Paysera\LoggingExtraBundle\Service\CorrelationIdProvider;
+use Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider;
 use Sentry\ClientInterface;
 
 /**
@@ -16,19 +17,23 @@ use Sentry\ClientInterface;
 class IterationEndListener
 {
     private CorrelationIdProvider $correlationIdProvider;
+    private ParentCorrelationIdProvider $parentCorrelationIdProvider;
     private ?ClientInterface $sentryClient;
 
     public function __construct(
         CorrelationIdProvider $correlationIdProvider,
+        ParentCorrelationIdProvider $parentCorrelationIdProvider,
         ?ClientInterface $sentryClient = null
     ) {
         $this->correlationIdProvider = $correlationIdProvider;
+        $this->parentCorrelationIdProvider = $parentCorrelationIdProvider;
         $this->sentryClient = $sentryClient;
     }
 
     public function afterIteration(): void
     {
         $this->correlationIdProvider->incrementIdentifier();
+        $this->parentCorrelationIdProvider->resetParentCorrelationId();
         if ($this->sentryClient !== null) {
             $this->sentryClient->flush();
         }

--- a/src/Listener/ParentCorrelationIdListener.php
+++ b/src/Listener/ParentCorrelationIdListener.php
@@ -36,6 +36,8 @@ class ParentCorrelationIdListener
 
         $headerValue = $event->getRequest()->headers->get(CorrelationIdListener::HEADER_NAME);
 
-        $this->parentCorrelationIdProvider->setParentCorrelationId($headerValue);
+        if ($headerValue !== null) {
+            $this->parentCorrelationIdProvider->setParentCorrelationId($headerValue);
+        }
     }
 }

--- a/src/Listener/ParentCorrelationIdListener.php
+++ b/src/Listener/ParentCorrelationIdListener.php
@@ -17,8 +17,6 @@ if (class_exists(RequestEvent::class)) {
 
 class ParentCorrelationIdListener
 {
-    public const HEADER_NAME = 'Paysera-Correlation-Id';
-
     private ParentCorrelationIdProvider $parentCorrelationIdProvider;
 
     public function __construct(ParentCorrelationIdProvider $parentCorrelationIdProvider)
@@ -36,7 +34,7 @@ class ParentCorrelationIdListener
             return;
         }
 
-        $headerValue = $event->getRequest()->headers->get(self::HEADER_NAME);
+        $headerValue = $event->getRequest()->headers->get(CorrelationIdListener::HEADER_NAME);
 
         $this->parentCorrelationIdProvider->setParentCorrelationId($headerValue);
     }

--- a/src/Listener/ParentCorrelationIdListener.php
+++ b/src/Listener/ParentCorrelationIdListener.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Listener;
+
+use Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent as LegacyRequestEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+if (class_exists(RequestEvent::class)) {
+    class_alias(RequestEvent::class, 'Paysera\LoggingExtraBundle\Listener\RequestEventAlias');
+} else {
+    class_alias(LegacyRequestEvent::class, 'Paysera\LoggingExtraBundle\Listener\RequestEventAlias');
+}
+
+class ParentCorrelationIdListener
+{
+    public const HEADER_NAME = 'X-Paysera-Correlation-Id';
+
+    private ParentCorrelationIdProvider $parentCorrelationIdProvider;
+
+    public function __construct(ParentCorrelationIdProvider $parentCorrelationIdProvider)
+    {
+        $this->parentCorrelationIdProvider = $parentCorrelationIdProvider;
+    }
+
+    public function onKernelRequest(RequestEventAlias $event): void
+    {
+        $mainRequestType = defined(HttpKernelInterface::class . '::MAIN_REQUEST')
+            ? HttpKernelInterface::MAIN_REQUEST
+            : HttpKernelInterface::MASTER_REQUEST;
+
+        if ($mainRequestType !== $event->getRequestType()) {
+            return;
+        }
+
+        $headerValue = $event->getRequest()->headers->get(self::HEADER_NAME);
+
+        $this->parentCorrelationIdProvider->setParentCorrelationId($headerValue);
+    }
+}

--- a/src/Listener/ParentCorrelationIdListener.php
+++ b/src/Listener/ParentCorrelationIdListener.php
@@ -17,7 +17,7 @@ if (class_exists(RequestEvent::class)) {
 
 class ParentCorrelationIdListener
 {
-    public const HEADER_NAME = 'X-Paysera-Correlation-Id';
+    public const HEADER_NAME = 'Paysera-Correlation-Id';
 
     private ParentCorrelationIdProvider $parentCorrelationIdProvider;
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,8 +14,7 @@
             <argument>%paysera_logging_extra.application_name%</argument>
         </service>
 
-        <service id="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"
-                 class="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"/>
+        <service id="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"/>
 
         <service id="paysera_logging_extra.sentry_handler" alias="paysera_logging_extra.handler.sentry"/>
     </services>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,7 +14,7 @@
             <argument>%paysera_logging_extra.application_name%</argument>
         </service>
 
-        <service id="paysera_logging_extra.parent_correlation_id_provider"
+        <service id="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"
                  class="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"/>
 
         <service id="paysera_logging_extra.sentry_handler" alias="paysera_logging_extra.handler.sentry"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,6 +14,9 @@
             <argument>%paysera_logging_extra.application_name%</argument>
         </service>
 
+        <service id="paysera_logging_extra.parent_correlation_id_provider"
+                 class="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"/>
+
         <service id="paysera_logging_extra.sentry_handler" alias="paysera_logging_extra.handler.sentry"/>
     </services>
 </container>

--- a/src/Resources/config/services/listeners.xml
+++ b/src/Resources/config/services/listeners.xml
@@ -11,6 +11,7 @@
             <tag name="kernel.event_listener" method="afterIteration" event="kernel.terminate"/>
 
             <argument type="service" id="paysera_logging_extra.correlation_id_provider"/>
+            <argument type="service" id="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"/>
             <argument type="service" id="Sentry\ClientInterface" on-invalid="null"/>
         </service>
 
@@ -21,8 +22,7 @@
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
         </service>
 
-        <service id="Paysera\LoggingExtraBundle\Listener\ParentCorrelationIdListener"
-                 class="Paysera\LoggingExtraBundle\Listener\ParentCorrelationIdListener">
+        <service id="Paysera\LoggingExtraBundle\Listener\ParentCorrelationIdListener">
             <argument type="service" id="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"/>
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="255"/>

--- a/src/Resources/config/services/listeners.xml
+++ b/src/Resources/config/services/listeners.xml
@@ -21,9 +21,9 @@
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
         </service>
 
-        <service id="paysera_logging_extra.listener.parent_correlation_id"
+        <service id="Paysera\LoggingExtraBundle\Listener\ParentCorrelationIdListener"
                  class="Paysera\LoggingExtraBundle\Listener\ParentCorrelationIdListener">
-            <argument type="service" id="paysera_logging_extra.parent_correlation_id_provider"/>
+            <argument type="service" id="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"/>
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="255"/>
         </service>

--- a/src/Resources/config/services/listeners.xml
+++ b/src/Resources/config/services/listeners.xml
@@ -20,5 +20,12 @@
 
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
         </service>
+
+        <service id="paysera_logging_extra.listener.parent_correlation_id"
+                 class="Paysera\LoggingExtraBundle\Listener\ParentCorrelationIdListener">
+            <argument type="service" id="paysera_logging_extra.parent_correlation_id_provider"/>
+
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="255"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/processors.xml
+++ b/src/Resources/config/services/processors.xml
@@ -27,8 +27,7 @@
             </argument>
         </service>
 
-        <service id="Paysera\LoggingExtraBundle\Service\Processor\ParentCorrelationIdProcessor"
-                 class="Paysera\LoggingExtraBundle\Service\Processor\ParentCorrelationIdProcessor">
+        <service id="Paysera\LoggingExtraBundle\Service\Processor\ParentCorrelationIdProcessor">
             <tag name="monolog.processor"/>
 
             <argument type="service" id="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"/>

--- a/src/Resources/config/services/processors.xml
+++ b/src/Resources/config/services/processors.xml
@@ -27,11 +27,11 @@
             </argument>
         </service>
 
-        <service id="paysera_logging_extra.processor.parent_correlation_id"
+        <service id="Paysera\LoggingExtraBundle\Service\Processor\ParentCorrelationIdProcessor"
                  class="Paysera\LoggingExtraBundle\Service\Processor\ParentCorrelationIdProcessor">
             <tag name="monolog.processor"/>
 
-            <argument type="service" id="paysera_logging_extra.parent_correlation_id_provider"/>
+            <argument type="service" id="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"/>
         </service>
 
         <service id="paysera_logging_extra.processor.sentry_context"

--- a/src/Resources/config/services/processors.xml
+++ b/src/Resources/config/services/processors.xml
@@ -27,6 +27,13 @@
             </argument>
         </service>
 
+        <service id="paysera_logging_extra.processor.parent_correlation_id"
+                 class="Paysera\LoggingExtraBundle\Service\Processor\ParentCorrelationIdProcessor">
+            <tag name="monolog.processor"/>
+
+            <argument type="service" id="paysera_logging_extra.parent_correlation_id_provider"/>
+        </service>
+
         <service id="paysera_logging_extra.processor.sentry_context"
                  class="Paysera\LoggingExtraBundle\Service\Processor\SentryContextProcessor">
             <tag name="monolog.processor" handler="sentry"/>

--- a/src/Service/ParentCorrelationIdProvider.php
+++ b/src/Service/ParentCorrelationIdProvider.php
@@ -6,7 +6,13 @@ namespace Paysera\LoggingExtraBundle\Service;
 
 class ParentCorrelationIdProvider
 {
-    private ?string $parentCorrelationId = null;
+
+    private ?string $parentCorrelationId;
+
+    public function __construct()
+    {
+        $this->parentCorrelationId = null;
+    }
 
     public function getParentCorrelationId(): ?string
     {

--- a/src/Service/ParentCorrelationIdProvider.php
+++ b/src/Service/ParentCorrelationIdProvider.php
@@ -19,8 +19,13 @@ class ParentCorrelationIdProvider
         return $this->parentCorrelationId;
     }
 
-    public function setParentCorrelationId(?string $parentCorrelationId): void
+    public function setParentCorrelationId(string $parentCorrelationId): void
     {
         $this->parentCorrelationId = $parentCorrelationId;
+    }
+
+    public function resetParentCorrelationId(): void
+    {
+        $this->parentCorrelationId = null;
     }
 }

--- a/src/Service/ParentCorrelationIdProvider.php
+++ b/src/Service/ParentCorrelationIdProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Service;
+
+class ParentCorrelationIdProvider
+{
+    private ?string $parentCorrelationId = null;
+
+    public function getParentCorrelationId(): ?string
+    {
+        return $this->parentCorrelationId;
+    }
+
+    public function setParentCorrelationId(?string $parentCorrelationId): void
+    {
+        $this->parentCorrelationId = $parentCorrelationId;
+    }
+}

--- a/src/Service/Processor/ParentCorrelationIdProcessor.php
+++ b/src/Service/Processor/ParentCorrelationIdProcessor.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Service\Processor;
+
+use Monolog\Processor\ProcessorInterface;
+use Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider;
+
+if (class_exists('Monolog\LogRecord')) {
+    class ParentCorrelationIdProcessor implements ProcessorInterface
+    {
+        private $parentCorrelationIdProvider;
+
+        public function __construct(ParentCorrelationIdProvider $parentCorrelationIdProvider)
+        {
+            $this->parentCorrelationIdProvider = $parentCorrelationIdProvider;
+        }
+
+        public function __invoke(\Monolog\LogRecord $record): \Monolog\LogRecord
+        {
+            $parentCorrelationId = $this->parentCorrelationIdProvider->getParentCorrelationId();
+
+            if ($parentCorrelationId === null) {
+                return $record;
+            }
+
+            return new \Monolog\LogRecord(
+                $record->datetime,
+                $record->channel,
+                $record->level,
+                $record->message,
+                $record->context,
+                array_merge($record->extra, ['parent_correlation_id' => $parentCorrelationId]),
+                $record->formatted
+            );
+        }
+    }
+} else {
+    class ParentCorrelationIdProcessor implements ProcessorInterface
+    {
+        private $parentCorrelationIdProvider;
+
+        public function __construct(ParentCorrelationIdProvider $parentCorrelationIdProvider)
+        {
+            $this->parentCorrelationIdProvider = $parentCorrelationIdProvider;
+        }
+
+        /**
+         * @param array $record
+         * @return array
+         */
+        public function __invoke($record)
+        {
+            $parentCorrelationId = $this->parentCorrelationIdProvider->getParentCorrelationId();
+
+            if ($parentCorrelationId === null) {
+                return $record;
+            }
+
+            $record['extra']['parent_correlation_id'] = $parentCorrelationId;
+            return $record;
+        }
+    }
+}

--- a/tests/Unit/Listener/IterationEndListenerTest.php
+++ b/tests/Unit/Listener/IterationEndListenerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Tests\Unit\Listener;
+
+use Paysera\LoggingExtraBundle\Listener\IterationEndListener;
+use Paysera\LoggingExtraBundle\Service\CorrelationIdProvider;
+use Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider;
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientInterface;
+
+class IterationEndListenerTest extends TestCase
+{
+    public function testAfterIterationIncrementsCorrelationIdAndResetsParentCorrelationId(): void
+    {
+        $correlationIdProvider = new CorrelationIdProvider('test');
+        $parentCorrelationIdProvider = new ParentCorrelationIdProvider();
+        $parentCorrelationIdProvider->setParentCorrelationId('parent-id-123');
+
+        $listener = new IterationEndListener($correlationIdProvider, $parentCorrelationIdProvider);
+
+        $correlationIdBefore = $correlationIdProvider->getCorrelationId();
+
+        $listener->afterIteration();
+
+        $this->assertNotSame($correlationIdBefore, $correlationIdProvider->getCorrelationId());
+        $this->assertNull($parentCorrelationIdProvider->getParentCorrelationId());
+    }
+
+    public function testAfterIterationFlushesSentryClient(): void
+    {
+        $correlationIdProvider = new CorrelationIdProvider('test');
+        $parentCorrelationIdProvider = new ParentCorrelationIdProvider();
+
+        $sentryClient = $this->createMock(ClientInterface::class);
+        $sentryClient->expects($this->once())->method('flush');
+
+        $listener = new IterationEndListener($correlationIdProvider, $parentCorrelationIdProvider, $sentryClient);
+
+        $listener->afterIteration();
+    }
+
+    public function testAfterIterationWorksWithoutSentryClient(): void
+    {
+        $correlationIdProvider = new CorrelationIdProvider('test');
+        $parentCorrelationIdProvider = new ParentCorrelationIdProvider();
+
+        $listener = new IterationEndListener($correlationIdProvider, $parentCorrelationIdProvider);
+
+        $listener->afterIteration();
+
+        $this->assertNull($parentCorrelationIdProvider->getParentCorrelationId());
+    }
+}

--- a/tests/Unit/Listener/ParentCorrelationIdListenerTest.php
+++ b/tests/Unit/Listener/ParentCorrelationIdListenerTest.php
@@ -26,7 +26,7 @@ class ParentCorrelationIdListenerTest extends TestCase
     public function testSetsParentCorrelationIdFromHeader(): void
     {
         $request = new Request();
-        $request->headers->set('X-Paysera-Correlation-Id', 'parent-id-123');
+        $request->headers->set('Paysera-Correlation-Id', 'parent-id-123');
 
         $mainRequestType = defined(HttpKernelInterface::class . '::MAIN_REQUEST')
             ? HttpKernelInterface::MAIN_REQUEST
@@ -59,7 +59,7 @@ class ParentCorrelationIdListenerTest extends TestCase
         $this->provider->setParentCorrelationId('existing-id');
 
         $request = new Request();
-        $request->headers->set('X-Paysera-Correlation-Id', 'sub-request-id');
+        $request->headers->set('Paysera-Correlation-Id', 'sub-request-id');
 
         $event = $this->createRequestEvent($request, HttpKernelInterface::SUB_REQUEST);
 

--- a/tests/Unit/Listener/ParentCorrelationIdListenerTest.php
+++ b/tests/Unit/Listener/ParentCorrelationIdListenerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Tests\Unit\Listener;
+
+use Paysera\LoggingExtraBundle\Listener\ParentCorrelationIdListener;
+use Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class ParentCorrelationIdListenerTest extends TestCase
+{
+    private ParentCorrelationIdProvider $provider;
+    private ParentCorrelationIdListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->provider = new ParentCorrelationIdProvider();
+        $this->listener = new ParentCorrelationIdListener($this->provider);
+    }
+
+    public function testSetsParentCorrelationIdFromHeader(): void
+    {
+        $request = new Request();
+        $request->headers->set('X-Paysera-Correlation-Id', 'parent-id-123');
+
+        $event = $this->createRequestEvent($request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertSame('parent-id-123', $this->provider->getParentCorrelationId());
+    }
+
+    public function testSetsNullWhenHeaderAbsent(): void
+    {
+        $request = new Request();
+
+        $event = $this->createRequestEvent($request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertNull($this->provider->getParentCorrelationId());
+    }
+
+    public function testIgnoresSubRequests(): void
+    {
+        $this->provider->setParentCorrelationId('existing-id');
+
+        $request = new Request();
+        $request->headers->set('X-Paysera-Correlation-Id', 'sub-request-id');
+
+        $event = $this->createRequestEvent($request, HttpKernelInterface::SUB_REQUEST);
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertSame('existing-id', $this->provider->getParentCorrelationId());
+    }
+
+    private function createRequestEvent(Request $request, int $requestType): RequestEvent
+    {
+        $kernel = $this->createMock(HttpKernelInterface::class);
+
+        return new RequestEvent($kernel, $request, $requestType);
+    }
+}

--- a/tests/Unit/Listener/ParentCorrelationIdListenerTest.php
+++ b/tests/Unit/Listener/ParentCorrelationIdListenerTest.php
@@ -28,7 +28,11 @@ class ParentCorrelationIdListenerTest extends TestCase
         $request = new Request();
         $request->headers->set('X-Paysera-Correlation-Id', 'parent-id-123');
 
-        $event = $this->createRequestEvent($request, HttpKernelInterface::MAIN_REQUEST);
+        $mainRequestType = defined(HttpKernelInterface::class . '::MAIN_REQUEST')
+            ? HttpKernelInterface::MAIN_REQUEST
+            : HttpKernelInterface::MASTER_REQUEST;
+
+        $event = $this->createRequestEvent($request, $mainRequestType);
 
         $this->listener->onKernelRequest($event);
 
@@ -39,7 +43,11 @@ class ParentCorrelationIdListenerTest extends TestCase
     {
         $request = new Request();
 
-        $event = $this->createRequestEvent($request, HttpKernelInterface::MAIN_REQUEST);
+        $mainRequestType = defined(HttpKernelInterface::class . '::MAIN_REQUEST')
+            ? HttpKernelInterface::MAIN_REQUEST
+            : HttpKernelInterface::MASTER_REQUEST;
+
+        $event = $this->createRequestEvent($request, $mainRequestType);
 
         $this->listener->onKernelRequest($event);
 

--- a/tests/Unit/Listener/ParentCorrelationIdListenerTest.php
+++ b/tests/Unit/Listener/ParentCorrelationIdListenerTest.php
@@ -39,8 +39,10 @@ class ParentCorrelationIdListenerTest extends TestCase
         $this->assertSame('parent-id-123', $this->provider->getParentCorrelationId());
     }
 
-    public function testSetsNullWhenHeaderAbsent(): void
+    public function testDoesNotSetWhenHeaderAbsent(): void
     {
+        $this->provider->setParentCorrelationId('existing-id');
+
         $request = new Request();
 
         $mainRequestType = defined(HttpKernelInterface::class . '::MAIN_REQUEST')
@@ -51,7 +53,7 @@ class ParentCorrelationIdListenerTest extends TestCase
 
         $this->listener->onKernelRequest($event);
 
-        $this->assertNull($this->provider->getParentCorrelationId());
+        $this->assertSame('existing-id', $this->provider->getParentCorrelationId());
     }
 
     public function testIgnoresSubRequests(): void

--- a/tests/Unit/Service/ParentCorrelationIdProviderTest.php
+++ b/tests/Unit/Service/ParentCorrelationIdProviderTest.php
@@ -25,12 +25,12 @@ class ParentCorrelationIdProviderTest extends TestCase
         $this->assertSame('abc-123', $provider->getParentCorrelationId());
     }
 
-    public function testSetToNull(): void
+    public function testResetParentCorrelationId(): void
     {
         $provider = new ParentCorrelationIdProvider();
 
         $provider->setParentCorrelationId('abc-123');
-        $provider->setParentCorrelationId(null);
+        $provider->resetParentCorrelationId();
 
         $this->assertNull($provider->getParentCorrelationId());
     }

--- a/tests/Unit/Service/ParentCorrelationIdProviderTest.php
+++ b/tests/Unit/Service/ParentCorrelationIdProviderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Tests\Unit\Service;
+
+use Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider;
+use PHPUnit\Framework\TestCase;
+
+class ParentCorrelationIdProviderTest extends TestCase
+{
+    public function testReturnsNullByDefault(): void
+    {
+        $provider = new ParentCorrelationIdProvider();
+
+        $this->assertNull($provider->getParentCorrelationId());
+    }
+
+    public function testSetAndGet(): void
+    {
+        $provider = new ParentCorrelationIdProvider();
+
+        $provider->setParentCorrelationId('abc-123');
+
+        $this->assertSame('abc-123', $provider->getParentCorrelationId());
+    }
+
+    public function testSetToNull(): void
+    {
+        $provider = new ParentCorrelationIdProvider();
+
+        $provider->setParentCorrelationId('abc-123');
+        $provider->setParentCorrelationId(null);
+
+        $this->assertNull($provider->getParentCorrelationId());
+    }
+}

--- a/tests/Unit/Service/Processor/ParentCorrelationIdProcessorTest.php
+++ b/tests/Unit/Service/Processor/ParentCorrelationIdProcessorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Tests\Unit\Service\Processor;
+
+use Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider;
+use Paysera\LoggingExtraBundle\Service\Processor\ParentCorrelationIdProcessor;
+use PHPUnit\Framework\TestCase;
+
+class ParentCorrelationIdProcessorTest extends TestCase
+{
+    private ParentCorrelationIdProvider $provider;
+    private ParentCorrelationIdProcessor $processor;
+
+    protected function setUp(): void
+    {
+        $this->provider = new ParentCorrelationIdProvider();
+        $this->processor = new ParentCorrelationIdProcessor($this->provider);
+    }
+
+    public function testAddsParentCorrelationIdWhenSet(): void
+    {
+        $this->provider->setParentCorrelationId('parent-id-123');
+
+        $record = $this->invokeProcessor();
+
+        $this->assertSame('parent-id-123', $this->getExtra($record, 'parent_correlation_id'));
+    }
+
+    public function testDoesNotAddKeyWhenNull(): void
+    {
+        $record = $this->invokeProcessor();
+
+        $this->assertArrayNotHasKey('parent_correlation_id', $this->getAllExtra($record));
+    }
+
+    /**
+     * @return \Monolog\LogRecord|array
+     */
+    private function invokeProcessor()
+    {
+        if (class_exists('Monolog\LogRecord')) {
+            $record = new \Monolog\LogRecord(
+                new \DateTimeImmutable(),
+                'test',
+                \Monolog\Level::Info,
+                'test message',
+                [],
+                [],
+            );
+        } else {
+            $record = [
+                'message' => 'test message',
+                'context' => [],
+                'level' => 200,
+                'level_name' => 'INFO',
+                'channel' => 'test',
+                'datetime' => new \DateTimeImmutable(),
+                'extra' => [],
+            ];
+        }
+
+        return ($this->processor)($record);
+    }
+
+    /**
+     * @param \Monolog\LogRecord|array $record
+     */
+    private function getExtra($record, string $key): string
+    {
+        if ($record instanceof \Monolog\LogRecord) {
+            return $record->extra[$key];
+        }
+
+        return $record['extra'][$key];
+    }
+
+    /**
+     * @param \Monolog\LogRecord|array $record
+     */
+    private function getAllExtra($record): array
+    {
+        if ($record instanceof \Monolog\LogRecord) {
+            return $record->extra;
+        }
+
+        return $record['extra'];
+    }
+}


### PR DESCRIPTION
Implement parent correlation ID capture in `paysera/lib-logging-extra-bundle`. When a service receives an HTTP request containing the `X-Paysera-Correlation-Id` header (set by an upstream calling), the system captures this value and includes it as `parent_correlation_id` in all Monolog log records.

### Changes
  - `ParentCorrelationIdProvider` — stores the parent correlation ID for the current request
  -  `ParentCorrelationIdListener` — `kernel.request` listener (priority 255, main request only) that reads the `X-Paysera-Correlation-Id` header
  - `ParentCorrelationIdProcessor` — Monolog processor that adds `parent_correlation_id` to log record `extra` when present (Monolog v1/v2/v3)
  - DI registration in `services.xml`, `listeners.xml`, `processors.xml`
  - Unit tests for all three components
 