### PR TITLE
LW-3297 Align parent correlation ID log key with access-log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.3.1
+### Changed
+- Renamed the parent correlation ID log field from `parent_correlation_id` to `parent_corr_id` to match the settled access-log format
+
 ## 3.3.0
 ### Added
 - Added `ParentCorrelationIdProvider` for extracting parent correlation ID from incoming request headers

--- a/src/Service/Processor/ParentCorrelationIdProcessor.php
+++ b/src/Service/Processor/ParentCorrelationIdProcessor.php
@@ -31,7 +31,7 @@ if (class_exists('Monolog\LogRecord')) {
                 $record->level,
                 $record->message,
                 $record->context,
-                array_merge($record->extra, ['parent_correlation_id' => $parentCorrelationId]),
+                array_merge($record->extra, ['parent_corr_id' => $parentCorrelationId]),
                 $record->formatted
             );
         }
@@ -58,7 +58,7 @@ if (class_exists('Monolog\LogRecord')) {
                 return $record;
             }
 
-            $record['extra']['parent_correlation_id'] = $parentCorrelationId;
+            $record['extra']['parent_corr_id'] = $parentCorrelationId;
             return $record;
         }
     }

--- a/tests/Unit/Service/Processor/ParentCorrelationIdProcessorTest.php
+++ b/tests/Unit/Service/Processor/ParentCorrelationIdProcessorTest.php
@@ -25,14 +25,14 @@ class ParentCorrelationIdProcessorTest extends TestCase
 
         $record = $this->invokeProcessor();
 
-        $this->assertSame('parent-id-123', $this->getExtra($record, 'parent_correlation_id'));
+        $this->assertSame('parent-id-123', $this->getExtra($record, 'parent_corr_id'));
     }
 
     public function testDoesNotAddKeyWhenNull(): void
     {
         $record = $this->invokeProcessor();
 
-        $this->assertArrayNotHasKey('parent_correlation_id', $this->getAllExtra($record));
+        $this->assertArrayNotHasKey('parent_corr_id', $this->getAllExtra($record));
     }
 
     /**


### PR DESCRIPTION
### Summary
Renames the parent correlation ID log field from `parent_correlation_id` to `parent_corr_id` to match the settled access-log format. Targets release **3.3.1** (patch).

### Changes
- `ParentCorrelationIdProcessor` — rename the `extra` field in both the Monolog `LogRecord` path and the legacy array path
- `ParentCorrelationIdProcessorTest` — update assertions for the new key
- `CHANGELOG.md` — add `## 3.3.1` entry (`Changed`)

### Impact
Wire-format change for log consumers: anything filtering/aggregating on `parent_correlation_id` must switch to `parent_corr_id`. Part of the not-yet-released 3.3.0 feature, so no production consumers should depend on the old key yet.

### Test plan
- [ ] `composer install`
- [ ] `vendor/bin/phpunit --filter ParentCorrelationIdProcessor`
