### PR TITLE
LW-3297 Harden parent correlation ID capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.3.2
+### Security
+- Validate the parent correlation ID in `ParentCorrelationIdProvider::setParentCorrelationId()` — the single place the invariant is enforced for every caller. Values that are empty, longer than 128 characters, or contain characters outside `[A-Za-z0-9._-]` are ignored, so a hostile `Paysera-Correlation-Id` header cannot inject control characters or bloat log lines and Sentry tags
+
+### Fixed
+- Reset the parent correlation ID at the start of every main HTTP request so a value captured on a previous request cannot leak into a later one handled by the same reused process (e.g. RoadRunner)
+
 ## 3.3.1
 ### Changed
 - Renamed the parent correlation ID log field from `parent_correlation_id` to `parent_corr_id` to match the settled access-log format

--- a/src/Listener/ParentCorrelationIdListener.php
+++ b/src/Listener/ParentCorrelationIdListener.php
@@ -34,6 +34,8 @@ class ParentCorrelationIdListener
             return;
         }
 
+        $this->parentCorrelationIdProvider->resetParentCorrelationId();
+
         $headerValue = $event->getRequest()->headers->get(CorrelationIdListener::HEADER_NAME);
 
         if ($headerValue !== null) {

--- a/src/Service/ParentCorrelationIdProvider.php
+++ b/src/Service/ParentCorrelationIdProvider.php
@@ -6,6 +6,9 @@ namespace Paysera\LoggingExtraBundle\Service;
 
 class ParentCorrelationIdProvider
 {
+    private const MAX_LENGTH = 128;
+
+    private const PATTERN = '/^[A-Za-z0-9._-]+\z/';
 
     private ?string $parentCorrelationId;
 
@@ -21,11 +24,22 @@ class ParentCorrelationIdProvider
 
     public function setParentCorrelationId(string $parentCorrelationId): void
     {
+        if (!self::isValid($parentCorrelationId)) {
+            return;
+        }
+
         $this->parentCorrelationId = $parentCorrelationId;
     }
 
     public function resetParentCorrelationId(): void
     {
         $this->parentCorrelationId = null;
+    }
+
+    private static function isValid(string $parentCorrelationId): bool
+    {
+        return $parentCorrelationId !== ''
+            && strlen($parentCorrelationId) <= self::MAX_LENGTH
+            && preg_match(self::PATTERN, $parentCorrelationId) === 1;
     }
 }

--- a/tests/Unit/Listener/ParentCorrelationIdListenerTest.php
+++ b/tests/Unit/Listener/ParentCorrelationIdListenerTest.php
@@ -28,32 +28,108 @@ class ParentCorrelationIdListenerTest extends TestCase
         $request = new Request();
         $request->headers->set('Paysera-Correlation-Id', 'parent-id-123');
 
-        $mainRequestType = defined(HttpKernelInterface::class . '::MAIN_REQUEST')
-            ? HttpKernelInterface::MAIN_REQUEST
-            : HttpKernelInterface::MASTER_REQUEST;
-
-        $event = $this->createRequestEvent($request, $mainRequestType);
+        $event = $this->createRequestEvent($request, $this->mainRequestType());
 
         $this->listener->onKernelRequest($event);
 
         $this->assertSame('parent-id-123', $this->provider->getParentCorrelationId());
     }
 
-    public function testDoesNotSetWhenHeaderAbsent(): void
+    public function testResetsStaleValueWhenHeaderAbsent(): void
     {
-        $this->provider->setParentCorrelationId('existing-id');
+        $this->provider->setParentCorrelationId('stale-id');
 
         $request = new Request();
 
-        $mainRequestType = defined(HttpKernelInterface::class . '::MAIN_REQUEST')
-            ? HttpKernelInterface::MAIN_REQUEST
-            : HttpKernelInterface::MASTER_REQUEST;
-
-        $event = $this->createRequestEvent($request, $mainRequestType);
+        $event = $this->createRequestEvent($request, $this->mainRequestType());
 
         $this->listener->onKernelRequest($event);
 
-        $this->assertSame('existing-id', $this->provider->getParentCorrelationId());
+        $this->assertNull($this->provider->getParentCorrelationId());
+    }
+
+    public function testResetsStaleValueWhenHeaderEmpty(): void
+    {
+        $this->provider->setParentCorrelationId('stale-id');
+
+        $request = new Request();
+        $request->headers->set('Paysera-Correlation-Id', '');
+
+        $event = $this->createRequestEvent($request, $this->mainRequestType());
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertNull($this->provider->getParentCorrelationId());
+    }
+
+    public function testResetsStaleValueWhenHeaderTooLong(): void
+    {
+        $this->provider->setParentCorrelationId('stale-id');
+
+        $request = new Request();
+        $request->headers->set('Paysera-Correlation-Id', str_repeat('a', 129));
+
+        $event = $this->createRequestEvent($request, $this->mainRequestType());
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertNull($this->provider->getParentCorrelationId());
+    }
+
+    /**
+     * @dataProvider provideInvalidCharsetHeaders
+     */
+    public function testResetsStaleValueWhenHeaderHasInvalidCharset(string $headerValue): void
+    {
+        $this->provider->setParentCorrelationId('stale-id');
+
+        $request = new Request();
+        $request->headers->set('Paysera-Correlation-Id', $headerValue);
+
+        $event = $this->createRequestEvent($request, $this->mainRequestType());
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertNull($this->provider->getParentCorrelationId());
+    }
+
+    public function testOverwritesStaleValueWithValidHeader(): void
+    {
+        $this->provider->setParentCorrelationId('stale-id');
+
+        $request = new Request();
+        $request->headers->set('Paysera-Correlation-Id', 'fresh-id-456');
+
+        $event = $this->createRequestEvent($request, $this->mainRequestType());
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertSame('fresh-id-456', $this->provider->getParentCorrelationId());
+    }
+
+    public function provideInvalidCharsetHeaders(): array
+    {
+        return [
+            'space' => ['parent id 123'],
+            'newline injection' => ["parent-id\ninjected=value"],
+            'tab' => ["parent-id\t123"],
+            'structural punctuation' => ['parent-id{"key":"value"}'],
+            'slash' => ['parent/id/123'],
+        ];
+    }
+
+    public function testAcceptsMaxLengthHeader(): void
+    {
+        $value = str_repeat('a', 128);
+
+        $request = new Request();
+        $request->headers->set('Paysera-Correlation-Id', $value);
+
+        $event = $this->createRequestEvent($request, $this->mainRequestType());
+
+        $this->listener->onKernelRequest($event);
+
+        $this->assertSame($value, $this->provider->getParentCorrelationId());
     }
 
     public function testIgnoresSubRequests(): void
@@ -75,5 +151,12 @@ class ParentCorrelationIdListenerTest extends TestCase
         $kernel = $this->createMock(HttpKernelInterface::class);
 
         return new RequestEvent($kernel, $request, $requestType);
+    }
+
+    private function mainRequestType(): int
+    {
+        return defined(HttpKernelInterface::class . '::MAIN_REQUEST')
+            ? HttpKernelInterface::MAIN_REQUEST
+            : HttpKernelInterface::MASTER_REQUEST;
     }
 }

--- a/tests/Unit/Service/ParentCorrelationIdProviderTest.php
+++ b/tests/Unit/Service/ParentCorrelationIdProviderTest.php
@@ -34,4 +34,52 @@ class ParentCorrelationIdProviderTest extends TestCase
 
         $this->assertNull($provider->getParentCorrelationId());
     }
+
+    public function testAcceptsMaxLengthValue(): void
+    {
+        $provider = new ParentCorrelationIdProvider();
+        $value = str_repeat('a', 128);
+
+        $provider->setParentCorrelationId($value);
+
+        $this->assertSame($value, $provider->getParentCorrelationId());
+    }
+
+    /**
+     * @dataProvider provideInvalidValues
+     */
+    public function testIgnoresInvalidValue(string $value): void
+    {
+        $provider = new ParentCorrelationIdProvider();
+
+        $provider->setParentCorrelationId($value);
+
+        $this->assertNull($provider->getParentCorrelationId());
+    }
+
+    /**
+     * @dataProvider provideInvalidValues
+     */
+    public function testInvalidValueDoesNotClobberExistingValue(string $value): void
+    {
+        $provider = new ParentCorrelationIdProvider();
+        $provider->setParentCorrelationId('valid-id');
+
+        $provider->setParentCorrelationId($value);
+
+        $this->assertSame('valid-id', $provider->getParentCorrelationId());
+    }
+
+    public function provideInvalidValues(): array
+    {
+        return [
+            'empty' => [''],
+            'too long' => [str_repeat('a', 129)],
+            'space' => ['parent id'],
+            'newline injection' => ["parent-id\ninjected=value"],
+            'tab' => ["parent-id\t123"],
+            'structural punctuation' => ['parent-id{"key":"value"}'],
+            'slash' => ['parent/id/123'],
+        ];
+    }
 }


### PR DESCRIPTION
### Summary

Makes capture of the client-controlled `Paysera-Correlation-Id` header safe: the parent ID is **validated in the provider** (the single place the invariant is enforced for every caller) and **reset at the start of every main HTTP request** so it can't leak across requests in a reused process. Log output for legitimate IDs is unchanged.

### Why

This bundle emits the incoming header as `parent_corr_id` to link cross-service traces. The value is **client-controlled** but was captured verbatim with no bounds:

- an empty header produced an empty `parent_corr_id` (no tracing value);
- an arbitrarily long or hostile value could inject control characters / whitespace / structural punctuation into every log line and Sentry tag (log injection, bloat);
- on the HTTP path the captured value was never reset at request start, so in a long-running/reused process (e.g. RoadRunner) a parent ID from a previous request could leak into a later request carrying no header.

### What changed

**`ParentCorrelationIdProvider` — single owner of the validation rule**
- `setParentCorrelationId()` validates and **silently ignores** an invalid value (empty, longer than `MAX_LENGTH = 128`, or outside `PATTERN = /^[A-Za-z0-9._-]+\z/`). An existing valid value is not clobbered by a subsequent invalid one.
- `128` stays under Sentry's 200-char tag limit; the charset is the alphabet the bundle's own correlation ID generator emits. `\z` (not `$`) anchors strictly so a trailing newline cannot slip through.

**`ParentCorrelationIdListener` — pure consumer**
- Resets the provider at the start of every main request, before reading the header (the worker path was already reset via `IterationEndListener`; this closes the HTTP path).
- Reads the header and hands it to the provider; validation is the provider's responsibility.

### Design notes

- **Validation lives in the provider, silently dropping invalid input** rather than throwing. A correlation ID is best-effort tracing metadata that must never break a request or worker, so ignoring a malformed value is the correct contract for *every* caller — and it keeps the listener trivial with no exception handling on the request path.
- **BC.** `setParentCorrelationId()` now ignores values it previously stored verbatim (empty / out-of-charset / >128 chars); observable log output for legitimate IDs is identical.

### Tests / Test plan

- `composer install`
- `vendor/bin/phpunit` → **47 tests, 1191 assertions, green**.

Coverage added:
- Provider: max-length (128) accepted; invalid values (empty, 129 chars, space, newline injection, tab, JSON punctuation, slash) ignored and do not clobber an existing valid value.
- Listener: valid capture, max-length accept, stale-value reset on absent/empty/too-long/invalid-charset header, valid-header overwrite of a stale value, sub-requests still ignored.

Reviewer check: capture behavior for legitimate IDs is unchanged; only empty/over-length/out-of-charset values are dropped, and the HTTP path no longer leaks a stale parent ID across requests.

### Housekeeping

- `CHANGELOG.md`: `## 3.3.2` — `### Security` (provider-enforced validation) and `### Fixed` (request-start reset).
