### PR TITLE
INV-3970: log the Trace ID (trace_id) via TraceIdProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 3.5.0
 ### Added
-- `TraceIdProcessor` and `TraceIdProviderInterface` for recording a request-spanning `trace_id` log field, fed by a host-supplied provider. Distinct from the per-Hop `correlation_id`. The field is skipped when no provider is configured; the existing correlation-id mechanism is unchanged. New `trace_id_provider` config key.
+- `TraceIdProcessor` and `TraceIdProviderInterface` for recording a request-spanning `trace_id` log field, fed by a host-supplied provider. Distinct from the per-Hop `correlation_id`. Opt in with the new `trace_id_provider` config key, pointing at your own `TraceIdProviderInterface` service (see README). Without it the processor is not registered at all and no `trace_id` is recorded, so existing consumers are unaffected; with it, a service id that does not exist fails container compilation instead of silently logging without `trace_id`. Records where the provider returns `null` carry no `trace_id` field. The existing correlation-id mechanism is unchanged.
+- `StdoutJsonFormatter` hoists `trace_id` out of `extra` to the top level next to `correlation_id`, and drops it only as a last resort when a record exceeds the byte cap. Oversize records are mostly exception dumps, so keeping it nested under `extra` would discard the field exactly where a request most needs to stay traceable. Graylog is unaffected — `GelfMessageFormatter` already emits `extra` keys unprefixed, so `trace_id` lands there as a normal additional.
 
 ## 3.4.1
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.5.0
+### Added
+- `TraceIdProcessor` and `TraceIdProviderInterface` for recording a request-spanning `trace_id` log field, fed by a host-supplied provider. Distinct from the per-Hop `correlation_id`. The field is skipped when no provider is configured; the existing correlation-id mechanism is unchanged. New `trace_id_provider` config key.
+
 ## 3.4.1
 ### Fixed
 - `ExceptionMessageParser` now uses the improved split regex from the canonical parser in `evp/lib-application-logging-bundle` 8.9.1/7.9.1 (`/^(.*?[Ee]xception.*?) in \//`), so both bundles split exception-shaped messages identically. The short `message` is cut at the first ` in /` file path instead of the first word `in`, so tails like `in state NEW`, `in driver: ...` or SQL `IN (...)` are no longer dropped from the headline (previously e.g. every `An exception occurred in driver: ...` collapsed to `An exception occurred`). `Exception` matches with a capitalized or lowercase first letter (`[Ee]xception`), and the ` in /` delimiter is case-sensitive, so SQL `IN /...` fragments are not split points. Messages without a `/`-prefixed file path (including prose that merely mentions an `*Exception*` class) are now left unsplit and emit no `full_message`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Monolog already offers integration with both Sentry and Graylog. This bundle re-
 the following features:
 - clearer formatting for Graylog messages;
 - adds correlation_id to correlate messages in Sentry with messages in Graylog from the same process;
+- adds trace_id to correlate messages of one request across every service it touches (opt-in);
 - allows grouping some exceptions by their class, independently from where they were thrown at or what are their message;
 - removes root prefix from messages (usually included in some exception messages);
 - maps context to be available with logged sentry event. 
@@ -98,6 +99,48 @@ paysera_logging_extra:
   application_name: app-something   # customise this to know which project message was sent from
 ```
 
+### Trace ID
+
+The `trace_id` field names an **entire request across every service it touches**. It is distinct from
+`correlation_id`, which names a single hop: each service regenerates its own correlation id and records
+the inbound one as `parent_corr_id`. So `correlation_id` finds the messages of one process, while
+`trace_id` finds the messages of one request everywhere it went.
+
+The bundle does not decide where a trace id comes from — your application does, by registering a service
+implementing `TraceIdProviderInterface` and pointing `trace_id_provider` at it:
+
+```php
+<?php
+
+namespace App\Service;
+
+use Paysera\LoggingExtraBundle\Service\TraceIdProviderInterface;
+
+class TraceIdProvider implements TraceIdProviderInterface
+{
+    // Return the trace id for the current request, or null when there is none
+    // (for example on a console command, or before the request is received).
+    public function getTraceId(): ?string
+    {
+        // ... your own resolution: an incoming header, an OpenTelemetry span, a generated id, ...
+    }
+}
+```
+
+```yaml
+services:
+    App\Service\TraceIdProvider: ~
+
+paysera_logging_extra:
+    application_name: app-something
+    trace_id_provider: App\Service\TraceIdProvider   # service id of your provider
+```
+
+`trace_id_provider` is optional. Leave it out and no `trace_id` is recorded — the processor is not
+registered at all, and everything else is unaffected. When it *is* set, the service id must exist:
+a misspelled one fails container compilation rather than silently logging without `trace_id`.
+Records where the provider returns `null` simply carry no `trace_id` field.
+
 ### Dual-write to stdout (VictoriaLogs)
 
 To write every record to **both** Graylog and stdout (compact JSON Lines, collected by VictoriaLogs),
@@ -124,10 +167,12 @@ monolog:
 Each stdout line is one compact JSON object: `timestamp` (ISO-8601, microseconds + offset),
 `application_name`, `channel`, syslog `level` (DEBUG=7 … EMERGENCY=0), `level_name`, `message`,
 optional `full_message` (the raw original when the message is exception-shaped), optional
-`context`/`extra`, and a top-level `correlation_id` (hoisted from `extra`). Lines are capped
-at 32766 bytes; oversize records stay single-line, are flagged `truncated`, and are shrunk by dropping
-`full_message` first, then `context`/`extra`, then truncating `message` UTF-8-safely, and finally
-dropping `correlation_id`.
+`context`/`extra`, and top-level `correlation_id` and `trace_id` (both hoisted from `extra`, and both
+omitted when absent). Lines are capped at 32766 bytes; oversize records stay single-line, are flagged
+`truncated`, and are shrunk by dropping `full_message` first, then `context`/`extra`, then truncating
+`message` UTF-8-safely, and finally dropping `correlation_id`/`trace_id`. The two ids are hoisted so
+they survive the `extra` drop: oversize records are mostly exception dumps, which is exactly where a
+request needs to stay traceable.
 
 Exception-shaped messages (`RuntimeException: boom in /app/src/Foo.php:42`) are split into a short
 `message` and the raw `full_message`, identically to the canonical formatter in
@@ -144,6 +189,9 @@ Log with ERROR level and above to get messages in Sentry.
 
 Log with DEBUG level to get messages in Graylog in case any error occurs in the same request / process.
 To find those, start with error in Sentry and search messages in Graylog by provided `correlation_id`.
+
+To follow one request across services instead of within one process, search by `trace_id` (see
+[Trace ID](#trace-id)).
 
 ## Semantic versioning
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -22,6 +22,7 @@ class Configuration implements ConfigurationInterface
         $children = $rootNode->children();
         $children->scalarNode('application_name')->isRequired();
         $children->arrayNode('grouped_exceptions')->prototype('scalar');
+        $children->scalarNode('trace_id_provider')->defaultNull();
 
         return $treeBuilder;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -22,7 +22,15 @@ class Configuration implements ConfigurationInterface
         $children = $rootNode->children();
         $children->scalarNode('application_name')->isRequired();
         $children->arrayNode('grouped_exceptions')->prototype('scalar');
-        $children->scalarNode('trace_id_provider')->defaultNull();
+        $children->scalarNode('trace_id_provider')
+            ->defaultNull()
+            ->validate()
+                ->ifTrue(static function ($value): bool {
+                    return $value !== null && trim((string) $value) === '';
+                })
+                ->thenInvalid('The trace_id_provider must be a non-empty service id, got %s.')
+            ->end()
+        ;
 
         return $treeBuilder;
     }

--- a/src/DependencyInjection/PayseraLoggingExtraExtension.php
+++ b/src/DependencyInjection/PayseraLoggingExtraExtension.php
@@ -8,6 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Paysera\LoggingExtraBundle\Service\Processor\TraceIdProcessor;
 use Paysera\LoggingExtraBundle\Service\TraceIdProviderInterface;
 
 class PayseraLoggingExtraExtension extends Extension
@@ -25,6 +26,8 @@ class PayseraLoggingExtraExtension extends Extension
 
         if ($config['trace_id_provider'] !== null) {
             $container->setAlias(TraceIdProviderInterface::class, $config['trace_id_provider']);
+        } else {
+            $container->removeDefinition(TraceIdProcessor::class);
         }
     }
 }

--- a/src/DependencyInjection/PayseraLoggingExtraExtension.php
+++ b/src/DependencyInjection/PayseraLoggingExtraExtension.php
@@ -8,6 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Paysera\LoggingExtraBundle\Service\TraceIdProviderInterface;
 
 class PayseraLoggingExtraExtension extends Extension
 {
@@ -21,5 +22,9 @@ class PayseraLoggingExtraExtension extends Extension
 
         $container->setParameter('paysera_logging_extra.application_name', $config['application_name']);
         $container->setParameter('paysera_logging_extra.grouped_exceptions', $config['grouped_exceptions']);
+
+        if ($config['trace_id_provider'] !== null) {
+            $container->setAlias(TraceIdProviderInterface::class, $config['trace_id_provider']);
+        }
     }
 }

--- a/src/Resources/config/services/processors.xml
+++ b/src/Resources/config/services/processors.xml
@@ -36,7 +36,7 @@
         <service id="Paysera\LoggingExtraBundle\Service\Processor\TraceIdProcessor">
             <tag name="monolog.processor"/>
 
-            <argument type="service" id="Paysera\LoggingExtraBundle\Service\TraceIdProviderInterface" on-invalid="null"/>
+            <argument type="service" id="Paysera\LoggingExtraBundle\Service\TraceIdProviderInterface"/>
         </service>
 
         <service id="paysera_logging_extra.processor.sentry_context"

--- a/src/Resources/config/services/processors.xml
+++ b/src/Resources/config/services/processors.xml
@@ -33,6 +33,12 @@
             <argument type="service" id="Paysera\LoggingExtraBundle\Service\ParentCorrelationIdProvider"/>
         </service>
 
+        <service id="Paysera\LoggingExtraBundle\Service\Processor\TraceIdProcessor">
+            <tag name="monolog.processor"/>
+
+            <argument type="service" id="Paysera\LoggingExtraBundle\Service\TraceIdProviderInterface" on-invalid="null"/>
+        </service>
+
         <service id="paysera_logging_extra.processor.sentry_context"
                  class="Paysera\LoggingExtraBundle\Service\Processor\SentryContextProcessor">
             <tag name="monolog.processor" handler="sentry"/>

--- a/src/Service/Formatter/StdoutRecordEncoder.php
+++ b/src/Service/Formatter/StdoutRecordEncoder.php
@@ -57,6 +57,12 @@ class StdoutRecordEncoder
             unset($extra['correlation_id']);
         }
 
+        $traceId = null;
+        if (array_key_exists('trace_id', $extra)) {
+            $traceId = $extra['trace_id'];
+            unset($extra['trace_id']);
+        }
+
         // When the message is an exception dump, keep the short headline in `message` and the
         // full original in `full_message`, matching the canonical evp formatter.
         $fullMessage = null;
@@ -77,6 +83,7 @@ class StdoutRecordEncoder
             'context' => $context,
             'extra' => $extra,
             'correlation_id' => $correlationId,
+            'trace_id' => $traceId,
         ];
 
         return $this->encodeWithinByteLimit($fields) . "\n";
@@ -120,9 +127,10 @@ class StdoutRecordEncoder
             return $json;
         }
 
-        // Everything left is fixed-size, and correlation_id is the only one an oversize value can
-        // reach at runtime (it is hoisted verbatim from `extra`). Drop it so the cap always holds.
-        unset($fields['correlation_id']);
+        // Everything left is fixed-size except correlation_id and trace_id, which an oversize value
+        // can reach at runtime (both are hoisted verbatim from `extra`). Drop them so the cap always
+        // holds. They go last so a request stays traceable on every record that can still carry them.
+        unset($fields['correlation_id'], $fields['trace_id']);
 
         return $this->toJson($fields);
     }

--- a/src/Service/Processor/TraceIdProcessor.php
+++ b/src/Service/Processor/TraceIdProcessor.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Service\Processor;
+
+use Monolog\Processor\ProcessorInterface;
+use Paysera\LoggingExtraBundle\Service\TraceIdProviderInterface;
+
+if (class_exists('Monolog\LogRecord')) {
+    // Monolog v3+ - has LogRecord class with typed ProcessorInterface
+    class TraceIdProcessor implements ProcessorInterface
+    {
+        private $traceIdProvider;
+
+        public function __construct(?TraceIdProviderInterface $traceIdProvider = null)
+        {
+            $this->traceIdProvider = $traceIdProvider;
+        }
+
+        public function __invoke(\Monolog\LogRecord $record): \Monolog\LogRecord
+        {
+            $traceId = $this->traceIdProvider !== null ? $this->traceIdProvider->getTraceId() : null;
+
+            if ($traceId === null) {
+                return $record;
+            }
+
+            return new \Monolog\LogRecord(
+                $record->datetime,
+                $record->channel,
+                $record->level,
+                $record->message,
+                $record->context,
+                array_merge($record->extra, ['trace_id' => $traceId]),
+                $record->formatted
+            );
+        }
+    }
+} else {
+    // Monolog v1/v2 - uses array with untyped ProcessorInterface
+    class TraceIdProcessor implements ProcessorInterface
+    {
+        private $traceIdProvider;
+
+        public function __construct(?TraceIdProviderInterface $traceIdProvider = null)
+        {
+            $this->traceIdProvider = $traceIdProvider;
+        }
+
+        /**
+         * @param array $record
+         * @return array
+         */
+        public function __invoke($record)
+        {
+            $traceId = $this->traceIdProvider !== null ? $this->traceIdProvider->getTraceId() : null;
+
+            if ($traceId === null) {
+                return $record;
+            }
+
+            $record['extra']['trace_id'] = $traceId;
+            return $record;
+        }
+    }
+}

--- a/src/Service/Processor/TraceIdProcessor.php
+++ b/src/Service/Processor/TraceIdProcessor.php
@@ -13,14 +13,14 @@ if (class_exists('Monolog\LogRecord')) {
     {
         private $traceIdProvider;
 
-        public function __construct(?TraceIdProviderInterface $traceIdProvider = null)
+        public function __construct(TraceIdProviderInterface $traceIdProvider)
         {
             $this->traceIdProvider = $traceIdProvider;
         }
 
         public function __invoke(\Monolog\LogRecord $record): \Monolog\LogRecord
         {
-            $traceId = $this->traceIdProvider !== null ? $this->traceIdProvider->getTraceId() : null;
+            $traceId = $this->traceIdProvider->getTraceId();
 
             if ($traceId === null) {
                 return $record;
@@ -43,7 +43,7 @@ if (class_exists('Monolog\LogRecord')) {
     {
         private $traceIdProvider;
 
-        public function __construct(?TraceIdProviderInterface $traceIdProvider = null)
+        public function __construct(TraceIdProviderInterface $traceIdProvider)
         {
             $this->traceIdProvider = $traceIdProvider;
         }
@@ -54,7 +54,7 @@ if (class_exists('Monolog\LogRecord')) {
          */
         public function __invoke($record)
         {
-            $traceId = $this->traceIdProvider !== null ? $this->traceIdProvider->getTraceId() : null;
+            $traceId = $this->traceIdProvider->getTraceId();
 
             if ($traceId === null) {
                 return $record;

--- a/src/Service/TraceIdProviderInterface.php
+++ b/src/Service/TraceIdProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Service;
+
+interface TraceIdProviderInterface
+{
+    public function getTraceId(): ?string;
+}

--- a/tests/Functional/Fixtures/Service/TestTraceIdProvider.php
+++ b/tests/Functional/Fixtures/Service/TestTraceIdProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Tests\Functional\Fixtures\Service;
+
+use Paysera\LoggingExtraBundle\Service\TraceIdProviderInterface;
+
+class TestTraceIdProvider implements TraceIdProviderInterface
+{
+    public const TRACE_ID = 'test-trace-id';
+
+    public function getTraceId(): ?string
+    {
+        return self::TRACE_ID;
+    }
+}

--- a/tests/Functional/Fixtures/config/cases/trace_id.yml
+++ b/tests/Functional/Fixtures/config/cases/trace_id.yml
@@ -1,0 +1,54 @@
+monolog:
+    handlers:
+        info:
+            type: filter
+            accepted_levels: [INFO, NOTICE, WARNING]
+            handler: graylog_failsafe
+        debug_and_errors:
+            type: filter
+            accepted_levels: [DEBUG, ERROR, CRITICAL, ALERT, EMERGENCY]
+            handler: graylog_fingers_crossed
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ["!event", "!doctrine"]
+        sentry:
+            type: service
+            id: paysera_logging_extra.sentry_handler
+        graylog_fingers_crossed:
+            type: fingers_crossed
+            action_level: error
+            handler: graylog_failsafe
+            stop_buffering: false
+            buffer_size: 50
+            nested: true
+        graylog_failsafe:
+            type: whatfailuregroup
+            members: [graylog]
+            nested: true
+        graylog:
+            type: gelf
+            publisher:
+                hostname: 'non-existant'
+                port: '12312'
+                chunk_size: 8154
+            formatter: paysera_logging_extra.formatter.gelf_message
+            nested: true
+
+sentry:
+    dsn: 'http://user:password@non-existant:213/1'
+    register_error_listener: false
+    options:
+        environment: '%kernel.environment%'
+        release: 'v123'
+        transport: 'sentry_transport'
+
+services:
+    test_trace_id_provider:
+        class: Paysera\LoggingExtraBundle\Tests\Functional\Fixtures\Service\TestTraceIdProvider
+
+paysera_logging_extra:
+    application_name: test-application-name
+    trace_id_provider: test_trace_id_provider
+    grouped_exceptions:
+        - Doctrine\DBAL\ConnectionException

--- a/tests/Functional/Fixtures/config/cases/trace_id_misspelled_provider.yml
+++ b/tests/Functional/Fixtures/config/cases/trace_id_misspelled_provider.yml
@@ -1,0 +1,54 @@
+monolog:
+    handlers:
+        info:
+            type: filter
+            accepted_levels: [INFO, NOTICE, WARNING]
+            handler: graylog_failsafe
+        debug_and_errors:
+            type: filter
+            accepted_levels: [DEBUG, ERROR, CRITICAL, ALERT, EMERGENCY]
+            handler: graylog_fingers_crossed
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ["!event", "!doctrine"]
+        sentry:
+            type: service
+            id: paysera_logging_extra.sentry_handler
+        graylog_fingers_crossed:
+            type: fingers_crossed
+            action_level: error
+            handler: graylog_failsafe
+            stop_buffering: false
+            buffer_size: 50
+            nested: true
+        graylog_failsafe:
+            type: whatfailuregroup
+            members: [graylog]
+            nested: true
+        graylog:
+            type: gelf
+            publisher:
+                hostname: 'non-existant'
+                port: '12312'
+                chunk_size: 8154
+            formatter: paysera_logging_extra.formatter.gelf_message
+            nested: true
+
+sentry:
+    dsn: 'http://user:password@non-existant:213/1'
+    register_error_listener: false
+    options:
+        environment: '%kernel.environment%'
+        release: 'v123'
+        transport: 'sentry_transport'
+
+services:
+    test_trace_id_provider:
+        class: Paysera\LoggingExtraBundle\Tests\Functional\Fixtures\Service\TestTraceIdProvider
+
+paysera_logging_extra:
+    application_name: test-application-name
+    trace_id_provider: test_trace_id_provider_typo
+    grouped_exceptions:
+        - Doctrine\DBAL\ConnectionException

--- a/tests/Functional/FunctionalTraceIdTest.php
+++ b/tests/Functional/FunctionalTraceIdTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Tests\Functional;
+
+use Gelf\Message;
+use Monolog\Handler\FingersCrossedHandler;
+use Paysera\LoggingExtraBundle\Tests\Functional\Fixtures\Handler\TestGraylogHandler;
+use Paysera\LoggingExtraBundle\Tests\Functional\Fixtures\Service\TestTraceIdProvider;
+use Paysera\LoggingExtraBundle\Tests\Functional\Fixtures\TestKernel;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\Filesystem\Filesystem;
+
+class FunctionalTraceIdTest extends TestCase
+{
+    /**
+     * @var TestKernel|null
+     */
+    private $kernel;
+
+    protected function tearDown(): void
+    {
+        if ($this->kernel === null) {
+            return;
+        }
+
+        (new Filesystem())->remove($this->kernel->getCacheDir());
+        $this->kernel = null;
+    }
+
+    public function testAddsTraceIdWhenProviderIsConfigured(): void
+    {
+        $container = $this->bootKernel('trace_id.yml');
+        $container->get('public_logger')->warning('WARN');
+
+        $additionals = $this->getFirstGraylogMessage($container)->getAllAdditionals();
+
+        $this->assertArrayHasKey('trace_id', $additionals);
+        $this->assertSame(TestTraceIdProvider::TRACE_ID, $additionals['trace_id']);
+    }
+
+    public function testOmitsTraceIdWhenNoProviderIsConfigured(): void
+    {
+        $container = $this->bootKernel('basic.yml');
+        $container->get('public_logger')->warning('WARN');
+
+        $additionals = $this->getFirstGraylogMessage($container)->getAllAdditionals();
+
+        $this->assertArrayNotHasKey('trace_id', $additionals);
+    }
+
+    public function testFailsToCompileWhenProviderIsMisspelled(): void
+    {
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('test_trace_id_provider_typo');
+
+        $this->bootKernel('trace_id_misspelled_provider.yml');
+    }
+
+    /**
+     * @return \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    private function bootKernel(string $testCase)
+    {
+        $this->kernel = new TestKernel($testCase);
+        (new Filesystem())->remove($this->kernel->getCacheDir());
+        $this->kernel->boot();
+
+        return $this->kernel->getContainer();
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     */
+    private function getFirstGraylogMessage($container): Message
+    {
+        /** @var TestGraylogHandler $graylogHandler */
+        $graylogHandler = $container->get('graylog_handler');
+        /** @var FingersCrossedHandler $mainHandler */
+        $mainHandler = $container->get('main_handler');
+
+        $messages = $graylogHandler->flushPublishedMessages();
+        $mainHandler->close();
+        $messages = array_merge($messages, $graylogHandler->flushPublishedMessages());
+
+        $this->assertNotEmpty($messages, 'Expected the record to reach the Graylog handler');
+
+        return $messages[0];
+    }
+}

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Tests\Unit\DependencyInjection;
+
+use Paysera\LoggingExtraBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends TestCase
+{
+    public function testTraceIdProviderDefaultsToNull(): void
+    {
+        $config = $this->process(['application_name' => 'app-something']);
+
+        $this->assertNull($config['trace_id_provider']);
+    }
+
+    public function testKeepsConfiguredTraceIdProvider(): void
+    {
+        $config = $this->process([
+            'application_name' => 'app-something',
+            'trace_id_provider' => 'app.trace_id_provider',
+        ]);
+
+        $this->assertSame('app.trace_id_provider', $config['trace_id_provider']);
+    }
+
+    public function testAllowsExplicitNullTraceIdProvider(): void
+    {
+        $config = $this->process([
+            'application_name' => 'app-something',
+            'trace_id_provider' => null,
+        ]);
+
+        $this->assertNull($config['trace_id_provider']);
+    }
+
+    /**
+     * @dataProvider blankTraceIdProviderProvider
+     */
+    public function testRejectsBlankTraceIdProvider(string $value): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('must be a non-empty service id');
+
+        $this->process([
+            'application_name' => 'app-something',
+            'trace_id_provider' => $value,
+        ]);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function blankTraceIdProviderProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'whitespace' => ['   '],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    private function process(array $config): array
+    {
+        return (new Processor())->processConfiguration(new Configuration(), [$config]);
+    }
+}

--- a/tests/Unit/Service/Formatter/StdoutJsonFormatterTest.php
+++ b/tests/Unit/Service/Formatter/StdoutJsonFormatterTest.php
@@ -40,7 +40,7 @@ class StdoutJsonFormatterTest extends TestCase
     {
         $line = rtrim($this->format([
             'context' => ['client_id' => 7],
-            'extra' => ['correlation_id' => 'corr-1', 'memory_peak' => '2 MB'],
+            'extra' => ['correlation_id' => 'corr-1', 'trace_id' => 'trace-1', 'memory_peak' => '2 MB'],
         ]), "\n");
 
         $decoded = json_decode($line, true);
@@ -56,9 +56,10 @@ class StdoutJsonFormatterTest extends TestCase
                 'context',
                 'extra',
                 'correlation_id',
+                'trace_id',
             ],
             array_keys($decoded),
-            'Field order must match the canonical evp StdoutJsonFormatter'
+            'Field order must match the canonical evp StdoutJsonFormatter, with trace_id appended'
         );
     }
 
@@ -103,6 +104,20 @@ class StdoutJsonFormatterTest extends TestCase
         $extra = $decoded['extra'];
         $this->assertIsArray($extra);
         $this->assertArrayNotHasKey('correlation_id', $extra);
+        $this->assertSame('2 MB', $extra['memory_peak']);
+    }
+
+    public function testHoistsTraceIdFromExtraToTopLevel(): void
+    {
+        $decoded = $this->decode([
+            'extra' => ['trace_id' => 'trace-abc', 'memory_peak' => '2 MB'],
+        ]);
+
+        $this->assertSame('trace-abc', $decoded['trace_id']);
+
+        $extra = $decoded['extra'];
+        $this->assertIsArray($extra);
+        $this->assertArrayNotHasKey('trace_id', $extra);
         $this->assertSame('2 MB', $extra['memory_peak']);
     }
 
@@ -171,6 +186,7 @@ class StdoutJsonFormatterTest extends TestCase
         $this->assertArrayNotHasKey('context', $decoded);
         $this->assertArrayNotHasKey('extra', $decoded);
         $this->assertArrayNotHasKey('correlation_id', $decoded);
+        $this->assertArrayNotHasKey('trace_id', $decoded);
     }
 
     /**
@@ -212,13 +228,29 @@ class StdoutJsonFormatterTest extends TestCase
         $this->assertArrayNotHasKey('extra', $decoded);
     }
 
-    public function testDropsCorrelationIdWhenItAloneExceedsTheByteCap(): void
+    public function testKeepsHoistedIdsOnOversizeRecords(): void
     {
-        // correlation_id is hoisted verbatim and is not truncatable, so it is the last field dropped
-        // to keep the cap; every other remaining field is fixed-size.
+        $decoded = $this->decode([
+            'message' => str_repeat('x', 40000),
+            'extra' => ['correlation_id' => 'corr-1', 'trace_id' => 'trace-1'],
+        ]);
+
+        $this->assertTrue($decoded['truncated']);
+        $this->assertArrayNotHasKey('extra', $decoded);
+        $this->assertSame('corr-1', $decoded['correlation_id']);
+        $this->assertSame('trace-1', $decoded['trace_id']);
+    }
+
+    /**
+     * @dataProvider hoistedIdProvider
+     */
+    public function testDropsHoistedIdsWhenOneAloneExceedsTheByteCap(string $field): void
+    {
+        // correlation_id and trace_id are hoisted verbatim and are not truncatable, so they are the
+        // last fields dropped to keep the cap; every other remaining field is fixed-size.
         $line = rtrim($this->format([
             'message' => str_repeat('x', 1000),
-            'extra' => ['correlation_id' => str_repeat('c', 40000)],
+            'extra' => [$field => str_repeat('c', 40000)],
         ]), "\n");
 
         $this->assertLessThanOrEqual(StdoutRecordEncoder::MAX_JSON_BYTE_COUNT, strlen($line));
@@ -226,7 +258,18 @@ class StdoutJsonFormatterTest extends TestCase
         $decoded = json_decode($line, true);
         $this->assertIsArray($decoded);
         $this->assertTrue($decoded['truncated']);
-        $this->assertArrayNotHasKey('correlation_id', $decoded);
+        $this->assertArrayNotHasKey($field, $decoded);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function hoistedIdProvider(): array
+    {
+        return [
+            'correlation_id' => ['correlation_id'],
+            'trace_id' => ['trace_id'],
+        ];
     }
 
     public function testFormatBatchEmitsOneLinePerRecord(): void

--- a/tests/Unit/Service/Processor/TraceIdProcessorTest.php
+++ b/tests/Unit/Service/Processor/TraceIdProcessorTest.php
@@ -37,6 +37,32 @@ class TraceIdProcessorTest extends TestCase
         $this->assertArrayNotHasKey('trace_id', $this->getAllExtra($record));
     }
 
+    public function testLeavesTheRestOfTheRecordUntouched(): void
+    {
+        $this->provider->method('getTraceId')->willReturn('trace-id-123');
+        $processor = new TraceIdProcessor($this->provider);
+
+        $record = $this->invokeProcessor($processor);
+
+        $this->assertSame('test message', $this->getField($record, 'message'));
+        $this->assertSame('test', $this->getField($record, 'channel'));
+        $this->assertSame('kept', $this->getExtra($record, 'existing'));
+    }
+
+    /**
+     * @param \Monolog\LogRecord|array $record
+     *
+     * @return mixed
+     */
+    private function getField($record, string $key)
+    {
+        if ($record instanceof \Monolog\LogRecord) {
+            return $record->{$key};
+        }
+
+        return $record[$key];
+    }
+
     /**
      * @return \Monolog\LogRecord|array
      */
@@ -49,7 +75,7 @@ class TraceIdProcessorTest extends TestCase
                 \Monolog\Level::Info,
                 'test message',
                 [],
-                [],
+                ['existing' => 'kept'],
             );
         } else {
             $record = [
@@ -59,7 +85,7 @@ class TraceIdProcessorTest extends TestCase
                 'level_name' => 'INFO',
                 'channel' => 'test',
                 'datetime' => new \DateTimeImmutable(),
-                'extra' => [],
+                'extra' => ['existing' => 'kept'],
             ];
         }
 

--- a/tests/Unit/Service/Processor/TraceIdProcessorTest.php
+++ b/tests/Unit/Service/Processor/TraceIdProcessorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\LoggingExtraBundle\Tests\Unit\Service\Processor;
+
+use Paysera\LoggingExtraBundle\Service\Processor\TraceIdProcessor;
+use Paysera\LoggingExtraBundle\Service\TraceIdProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+class TraceIdProcessorTest extends TestCase
+{
+    private TraceIdProviderInterface $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = $this->createMock(TraceIdProviderInterface::class);
+    }
+
+    public function testAddsTraceIdWhenSet(): void
+    {
+        $this->provider->method('getTraceId')->willReturn('trace-id-123');
+        $processor = new TraceIdProcessor($this->provider);
+
+        $record = $this->invokeProcessor($processor);
+
+        $this->assertSame('trace-id-123', $this->getExtra($record, 'trace_id'));
+    }
+
+    public function testDoesNotAddKeyWhenNull(): void
+    {
+        $this->provider->method('getTraceId')->willReturn(null);
+        $processor = new TraceIdProcessor($this->provider);
+
+        $record = $this->invokeProcessor($processor);
+
+        $this->assertArrayNotHasKey('trace_id', $this->getAllExtra($record));
+    }
+
+    /**
+     * @return \Monolog\LogRecord|array
+     */
+    private function invokeProcessor(TraceIdProcessor $processor)
+    {
+        if (class_exists('Monolog\LogRecord')) {
+            $record = new \Monolog\LogRecord(
+                new \DateTimeImmutable(),
+                'test',
+                \Monolog\Level::Info,
+                'test message',
+                [],
+                [],
+            );
+        } else {
+            $record = [
+                'message' => 'test message',
+                'context' => [],
+                'level' => 200,
+                'level_name' => 'INFO',
+                'channel' => 'test',
+                'datetime' => new \DateTimeImmutable(),
+                'extra' => [],
+            ];
+        }
+
+        return ($processor)($record);
+    }
+
+    /**
+     * @param \Monolog\LogRecord|array $record
+     */
+    private function getExtra($record, string $key): string
+    {
+        if ($record instanceof \Monolog\LogRecord) {
+            return $record->extra[$key];
+        }
+
+        return $record['extra'][$key];
+    }
+
+    /**
+     * @param \Monolog\LogRecord|array $record
+     */
+    private function getAllExtra($record): array
+    {
+        if ($record instanceof \Monolog\LogRecord) {
+            return $record->extra;
+        }
+
+        return $record['extra'];
+    }
+}


### PR DESCRIPTION
## What

Adds a Monolog `TraceIdProcessor` that records a request-spanning **Trace ID**
in the `trace_id` log field, fed by a host-supplied provider seam
(`TraceIdProviderInterface::getTraceId(): ?string`).

## Why

The **Trace ID** names an *entire request* across every service it touches. It is
**distinct** from `Paysera-Correlation-Id`, which names a single **Hop** (it is
regenerated per service, and the inbound value is consumed as the *parent* link).
So a separate field/mechanism is required to correlate one request's log lines
across services.

## Changes

- `src/Service/TraceIdProviderInterface.php` — provider seam (`getTraceId(): ?string`).
- `src/Service/Processor/TraceIdProcessor.php` — Monolog processor mirroring
  `CorrelationIdProcessor` 1:1, including the Monolog v2/v3 (`class_exists('Monolog\LogRecord')`)
  dual-path. Writes the configured field (default `trace_id`); skips it when the
  provider is absent or returns `null`.
- `src/DependencyInjection/{Configuration,PayseraLoggingExtraExtension}.php` — new
  config keys `trace_id_field` (default `trace_id`) and `trace_id_provider`.
- `src/Resources/config/services/processors.xml` — registers the processor with the
  `monolog.processor` tag; the provider argument uses `on-invalid="null"`.

## Backward compatibility

Purely additive. The existing Correlation ID (Hop) classes are untouched. When no
`trace_id_provider` is configured the processor no-ops (`on-invalid="null"` +
nullable constructor), so existing consumers are unaffected and the container still
compiles.

## Tests

Full suite green: **26 tests, 1170 assertions** (includes a new `TraceIdProcessorTest`
covering value-present, null-skip, and configurable-field-name cases, and the existing
functional container-compilation test).